### PR TITLE
fix: show home page to unauthenticated users and virtualize timeline

### DIFF
--- a/src/Server/Data/SQLiteItemRepository.cs
+++ b/src/Server/Data/SQLiteItemRepository.cs
@@ -404,7 +404,7 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
             bool useCursor = lastPublishDateOrder.HasValue && lastId.HasValue;
             if (useCursor)
             {
-                command.CommandText += " AND (i.PublishDateOrder < @lastOrder OR (i.PublishDateOrder = @lastOrder AND i.Id < @lastId))";
+                command.CommandText += " AND (i.PublishDateOrder, i.Id) < (@lastOrder, @lastId)";
                 command.Parameters.AddWithValue("@lastOrder", lastPublishDateOrder.Value);
                 command.Parameters.AddWithValue("@lastId", lastId.Value);
             }

--- a/src/WasmApp/Layout/NavMenu.razor
+++ b/src/WasmApp/Layout/NavMenu.razor
@@ -1,9 +1,11 @@
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Sections
 @using WasmApp.Services
 @using RssApp.Contracts
 
 @inject IUserClient userClient
+@inject AuthenticationStateProvider AuthStateProvider
 
 @rendermode InteractiveWebAssembly
 
@@ -135,6 +137,13 @@
 
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        if (authState.User?.Identity?.IsAuthenticated != true)
+        {
+            username = "Guest";
+            return;
+        }
+
         try
         {
             feedUser = await userClient.GetFeedUserAsync();

--- a/src/WasmApp/Pages/Base/PostPageBase.razor
+++ b/src/WasmApp/Pages/Base/PostPageBase.razor
@@ -10,6 +10,7 @@
     private bool _pendingForceReset;
     private string _scrollAnchorPostId;
     private bool _needsScrollRestore;
+    private bool _scrolledToEstimate;
     private int _restorePageSize;
     public List<NewsFeedItem> Items { get; set; } = new List<NewsFeedItem>();
     public int Page { get; set; } = 0;
@@ -105,6 +106,9 @@
             {
                 UpdateCursorFromItems(newPageRes);
             }
+
+            // Sync loaded item count to JS for scroll state estimation (works with Virtualize)
+            try { await jsRuntime.InvokeVoidAsync("rssApp.setLoadedItemCount", Items.Count); } catch { }
             
             this.StateHasChanged();
         }
@@ -235,11 +239,36 @@
         {
             try
             {
+                // With Virtualize, the target post may not be in the DOM yet.
+                // First try a direct scroll; if it fails, estimate position to trigger
+                // Virtualize to render items near the target, then retry next render.
                 var scrolled = await jsRuntime.InvokeAsync<bool>("rssApp.scrollToPost", _scrollAnchorPostId);
                 if (scrolled)
                 {
                     _needsScrollRestore = false;
                     _scrollAnchorPostId = null;
+                }
+                else if (!_scrolledToEstimate)
+                {
+                    // Find the target's index in the loaded items and scroll to estimated position
+                    var targetIndex = Items.FindIndex(i => i.Id == _scrollAnchorPostId);
+                    if (targetIndex >= 0)
+                    {
+                        // Add ~1.1x multiplier to account for day headers interspersed
+                        await jsRuntime.InvokeVoidAsync("rssApp.scrollToEstimatedIndex", (int)(targetIndex * 1.1), 72);
+                        _scrolledToEstimate = true;
+                    }
+                    else
+                    {
+                        _needsScrollRestore = false;
+                    }
+                }
+                else
+                {
+                    // Already scrolled to estimate but element still not found — give up
+                    _needsScrollRestore = false;
+                    _scrollAnchorPostId = null;
+                    _scrolledToEstimate = false;
                 }
             }
             catch (Exception)

--- a/src/WasmApp/Pages/Detail/PostTable.razor
+++ b/src/WasmApp/Pages/Detail/PostTable.razor
@@ -26,7 +26,7 @@
 
 
 <div id="post-table" class="table">
-    @if (isLoading)
+    @if (isLoading && (_flatEntries == null || _flatEntries.Count == 0))
     {
         <div class="loading-spinner-container">
             <div class="spinner"></div>
@@ -40,31 +40,26 @@
     }
     else
     {
-        <InfiniteScroll ObserverTargetId="observerTarget" ObservableTargetReached="(e) => Next()">
-            @{ bool isFirstGroup = true; }
-            @foreach (var dayGroup in Posts
-                .GroupBy(p => p.ParsedDate?.ToLocalTime().Date ?? DateTime.MinValue)
-                .OrderByDescending(g => g.Key))
+        <Virtualize @ref="_virtualizeRef" Items="@_flatEntries" Context="entry" ItemSize="72" OverscanCount="10" SpacerElement="div">
+            @if (entry.IsDayHeader)
             {
-                <div class="day-separator @(isFirstGroup ? "day-separator-first" : "")">@GetDayLabel(dayGroup.Key)</div>
-                isFirstGroup = false;
-                <div class="day-group">
-                @foreach (var post in dayGroup)
-                {
-                    <PostDetail @key="post.Id"
-                        Post="@post"
-                        FilterTag="@this.filterTag"
-                        IsFilterUnread="@this.IsFilterUnread"/>
-                }
-                </div>
+                <div @key="@entry.DayKey" class="day-separator @(entry.IsFirstHeader ? "day-separator-first" : "")">@GetDayLabel(entry.Date)</div>
             }
+            else
+            {
+                <PostDetail @key="entry.Post.Id"
+                    Post="@entry.Post"
+                    FilterTag="@this.filterTag"
+                    IsFilterUnread="@this.IsFilterUnread"/>
+            }
+        </Virtualize>
 
+        <InfiniteScroll ObserverTargetId="observerTarget" ObservableTargetReached="(e) => Next()">
             <div class="row">
                 <div id="observerTarget">
                     RssApp
                 </div>
             </div>
-            
         </InfiniteScroll>
     }
 </div>
@@ -90,14 +85,19 @@
     public bool IsFilterSaved => FeedClient.IsFilterSaved;
     private string filterTag => FeedClient.FilterTag;
 
-    private const int MaxPostsToKeep = 100;  // Adjust this number based on your needs
-
     private bool isLoading = true;
+    private Virtualize<TimelineEntry> _virtualizeRef;
+
+    // Pre-computed flat list for Virtualize — rebuilt only when Posts changes
+    private List<TimelineEntry> _flatEntries = new();
+    private int _lastPostsCount;
+
+    private record TimelineEntry(bool IsDayHeader, DateTime Date, string DayKey, bool IsFirstHeader, NewsFeedItem Post);
 
     public void Dispose()
     {
     }
-    
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
@@ -114,12 +114,40 @@
         if (Posts != null)
         {
             isLoading = false;
+            RebuildFlatEntries();
         }
+    }
+
+    private void RebuildFlatEntries()
+    {
+        if (Posts == null || Posts.Count == _lastPostsCount)
+            return;
+
+        _lastPostsCount = Posts.Count;
+        var entries = new List<TimelineEntry>(Posts.Count + 50);
+        bool isFirstGroup = true;
+
+        foreach (var dayGroup in Posts
+            .GroupBy(p => p.ParsedDate?.ToLocalTime().Date ?? DateTime.MinValue)
+            .OrderByDescending(g => g.Key))
+        {
+            var dayKey = $"day-{dayGroup.Key:yyyy-MM-dd}";
+            entries.Add(new TimelineEntry(true, dayGroup.Key, dayKey, isFirstGroup, null));
+            isFirstGroup = false;
+
+            foreach (var post in dayGroup)
+            {
+                entries.Add(new TimelineEntry(false, default, null, false, post));
+            }
+        }
+
+        _flatEntries = entries;
     }
 
     private async Task ToggleUnreadFilterAsync()
     {
         isLoading = true;
+        _lastPostsCount = 0; // force rebuild on next parameter set
         await this.OnRefreshTriggered.InvokeAsync((!this.IsFilterUnread, this.IsFilterSaved, this.filterTag, false));
         isLoading = false;
     }
@@ -127,6 +155,7 @@
     private async Task ToggleSavedFilterAsync()
     {
         isLoading = true;
+        _lastPostsCount = 0;
         await this.OnRefreshTriggered.InvokeAsync((this.IsFilterUnread, !this.IsFilterSaved, this.filterTag, false));
         isLoading = false;
     }
@@ -134,6 +163,7 @@
     private async Task FilterForTag(string tag)
     {
         isLoading = true;
+        _lastPostsCount = 0;
         if (this.filterTag == tag)
         {
             tag = null;
@@ -144,7 +174,7 @@
 
     private async Task OnRefreshComplete()
     {
-        // Re-fetch from the top with current filters — forceReset resets cursor so new posts appear
+        _lastPostsCount = 0;
         await this.OnRefreshTriggered.InvokeAsync((this.IsFilterUnread, this.IsFilterSaved, this.filterTag, true));
     }
 

--- a/src/WasmApp/Pages/Home.razor
+++ b/src/WasmApp/Pages/Home.razor
@@ -1,7 +1,9 @@
 ﻿@page "/"
 @page "/index"
 @using WasmApp.Services
+@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
+@attribute [AllowAnonymous]
 @inject NavigationManager NavigationManager
 @inject ILogger<Index> logger
 @inject IUserClient userClient
@@ -28,7 +30,7 @@
                 <div class="shell-line shell-cmd desktop-only" style="margin-top: 1.5rem;">$ press [ENTER] to continue<span class="shell-cursor">█</span></div>
                 @* Mobile: button *@
                 <div class="mobile-only" style="margin-top: 1.5rem;">
-                    <a href="/.auth/login/aad" class="btn btn-outline-success btn-sm" style="font-family: inherit; letter-spacing: 0.05em;">Login / Sign Up</a>
+                    <a href="@LoginUrl" class="btn btn-outline-success btn-sm" style="font-family: inherit; letter-spacing: 0.05em;">Login / Sign Up</a>
                 </div>
             </NotAuthorized>
         </AuthorizeView>
@@ -38,6 +40,12 @@
 @code {
     // Auto-focus for keyboard handling; FocusAsync runs after first render
     private ElementReference _terminalRef;
+    private string _returnUrl;
+
+    private string LoginUrl =>
+        string.IsNullOrEmpty(_returnUrl)
+            ? "/.auth/login/aad"
+            : $"/.auth/login/aad?post_login_redirect_uri={_returnUrl}";
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -51,7 +59,13 @@
                 return;
             }
 
+            // Read returnUrl from query string (set by RedirectToLogin for deep links)
+            var uri = new Uri(NavigationManager.Uri);
+            var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
+            _returnUrl = query["returnUrl"];
+
             await _terminalRef.FocusAsync();
+            StateHasChanged();
         }
     }
 
@@ -59,7 +73,7 @@
     {
         if (e.Key == "Enter")
         {
-            NavigationManager.NavigateTo("/.auth/login/aad", forceLoad: true);
+            NavigationManager.NavigateTo(LoginUrl, forceLoad: true);
         }
     }
 }

--- a/src/WasmApp/Services/RedirectToLogin.razor
+++ b/src/WasmApp/Services/RedirectToLogin.razor
@@ -1,14 +1,12 @@
 @inject NavigationManager NavigationManager
 
 @code {
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    protected override void OnAfterRender(bool firstRender)
     {
         if (firstRender)
         {
             var returnUrl = Uri.EscapeDataString(NavigationManager.Uri);
-            NavigationManager.NavigateTo(
-                $"/.auth/login/aad?post_login_redirect_uri={returnUrl}",
-                forceLoad: true);
+            NavigationManager.NavigateTo($"/?returnUrl={returnUrl}", replace: true);
         }
     }
 }

--- a/src/WasmApp/wwwroot/app.js
+++ b/src/WasmApp/wwwroot/app.js
@@ -121,8 +121,13 @@ window.Observer = {
 };
 
 window.rssApp = {
+    _loadedItemCount: 0,
+    setLoadedItemCount: function(count) {
+        window.rssApp._loadedItemCount = count;
+    },
     saveScrollStateAndNavigate: function(postId, targetHref, markReadUrl) {
-        var itemCount = document.querySelectorAll('[data-post-id]').length;
+        // Use Blazor-provided count (works with Virtualize) with DOM fallback
+        var itemCount = window.rssApp._loadedItemCount || document.querySelectorAll('[data-post-id]').length;
         var pageEstimate = Math.ceil(itemCount / 20);
         sessionStorage.setItem('rssApp.scrollAnchorPostId', postId);
         sessionStorage.setItem('rssApp.scrollAnchorPage', pageEstimate.toString());
@@ -144,6 +149,10 @@ window.rssApp = {
         sessionStorage.removeItem('rssApp.scrollAnchorPostId');
         sessionStorage.removeItem('rssApp.scrollAnchorPage');
         sessionStorage.removeItem('rssApp.scrollAnchorPath');
+    },
+    scrollToEstimatedIndex: function(index, itemSize) {
+        var estimatedPosition = index * itemSize;
+        window.scrollTo(0, estimatedPosition);
     },
     scrollToPost: function(postId) {
         var el = document.querySelector('[data-post-id="' + postId + '"]');


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Home page visible to unauthenticated users
- **Root cause**: NavMenu called \GetFeedUserAsync()\ on every page during init. For anonymous users, the 401 response triggered \AuthenticationHeaderHandler\ to auto-redirect to AAD login before the user ever saw the home page.
- **Fix**: Guard NavMenu API calls with \AuthenticationStateProvider\ check  skip for anonymous users. \RedirectToLogin\ now sends to \/?returnUrl=...\ instead of directly to AAD. Home.razor marked \[AllowAnonymous]\ with returnUrl deep-link support.

### 2. Timeline performance (Virtualize)
- **Root cause**: \PostTable.razor\ rendered ALL items with \@foreach\ + \GroupBy().OrderByDescending()\ LINQ on every \StateHasChanged()\, causing O(n) re-diffs with thousands of items.
- **Fix**: Replace with Blazor \<Virtualize>\ component on a pre-computed flat \TimelineEntry\ list. Only rebuilds when Posts actually changes. Backend cursor comparison changed to row-value syntax for efficient composite index seeks.

### Files changed
- \NavMenu.razor\  auth guard for API calls
- \RedirectToLogin.razor\  redirect to home with returnUrl
- \Home.razor\  \[AllowAnonymous]\, returnUrl handling
- \PostTable.razor\  Virtualize with pre-computed flat list
- \PostPageBase.razor\  JS item count sync + estimated-position scroll restoration
- \SQLiteItemRepository.cs\  row-value cursor comparison
- \pp.js\  \setLoadedItemCount\, \scrollToEstimatedIndex\

### Testing
- Build succeeds, all 110 passing tests pass (1 pre-existing failure in DatabaseBackupServiceTests)
- Local smoke test: timeline loads, day headers render, filters work, infinite scroll works, zero console errors