### PR TITLE
Fix logout: prevent auto re-login after /.auth/logout

### DIFF
--- a/src/WasmApp/Services/AuthenticationHeaderHandler.cs
+++ b/src/WasmApp/Services/AuthenticationHeaderHandler.cs
@@ -5,7 +5,7 @@ namespace WasmApp.Services;
 
 /// <summary>
 /// HTTP handler that ensures credentials (cookies) are sent with API requests
-/// and auto-redirects to login when the SWA Easy Auth session expires.
+/// and redirects appropriately when the SWA Easy Auth session expires.
 /// 
 /// SECURITY NOTE: We do NOT manually send identity headers. With Easy Auth:
 /// 1. User authenticates via /.auth/login/... 
@@ -15,16 +15,17 @@ namespace WasmApp.Services;
 /// 
 /// The browser cannot and should not forge identity headers - that's the platform's job.
 /// 
-/// SESSION EXPIRY: SWA sessions last ~8 hours, but the AAD browser session persists
-/// much longer. When a 401 is detected, we redirect to /.auth/login/aad which will
-/// silently re-authenticate if the AAD session is still valid (no password prompt).
+/// SESSION EXPIRY: SWA sessions last ~8 hours. When a 401 is detected, we re-check
+/// /.auth/me to distinguish intentional logout from session expiry:
+/// - If still authenticated: silently re-authenticate via /.auth/login/aad
+/// - If no longer authenticated: navigate home (user logged out intentionally)
 /// </summary>
 public class AuthenticationHeaderHandler : DelegatingHandler
 {
     private readonly AuthenticationStateProvider _authStateProvider;
     private readonly NavigationManager _navigationManager;
 
-    private static volatile bool _isRedirecting;
+    private static int _isRedirecting;
 
     public AuthenticationHeaderHandler(
         AuthenticationStateProvider authStateProvider,
@@ -38,13 +39,26 @@ public class AuthenticationHeaderHandler : DelegatingHandler
     {
         var response = await base.SendAsync(request, cancellationToken);
 
-        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized && !_isRedirecting)
+        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized
+            && Interlocked.CompareExchange(ref _isRedirecting, 1, 0) == 0)
         {
-            _isRedirecting = true;
+            var authState = await _authStateProvider.GetAuthenticationStateAsync();
             var returnUrl = Uri.EscapeDataString(_navigationManager.Uri);
-            _navigationManager.NavigateTo(
-                $"/.auth/login/aad?post_login_redirect_uri={returnUrl}",
-                forceLoad: true);
+
+            if (authState.User?.Identity?.IsAuthenticated == true)
+            {
+                // Session expired while user was authenticated - do silent re-auth and return to current page
+                _navigationManager.NavigateTo(
+                    $"/.auth/login/aad?post_login_redirect_uri={returnUrl}",
+                    forceLoad: true);
+            }
+            else
+            {
+                // User logged out intentionally - navigate home with returnUrl so they can log back in
+                _navigationManager.NavigateTo(
+                    $"/?returnUrl={returnUrl}",
+                    forceLoad: true);
+            }
         }
 
         return response;

--- a/src/WasmApp/Services/AuthenticationStateProvider.cs
+++ b/src/WasmApp/Services/AuthenticationStateProvider.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.WebAssembly.Http;
 using RssApp.Config;
 
 namespace WasmApp.Services;
@@ -31,7 +32,10 @@ public class MyAuthenticationStateProvider : AuthenticationStateProvider
 
         try
         {
-            var state = await _client.GetFromJsonAsync<UserAuthenticationState>("/.auth/me");
+            using var authRequest = new HttpRequestMessage(HttpMethod.Get, "/.auth/me");
+            authRequest.SetBrowserRequestCache(BrowserRequestCache.NoStore);
+            using var authResponse = await _client.SendAsync(authRequest);
+            var state = await authResponse.Content.ReadFromJsonAsync<UserAuthenticationState>();
 
             var principal = state.ClientPrincipal;
             principal.UserRoles = principal.UserRoles.Except(new string[] { "anonymous" }, StringComparer.CurrentCultureIgnoreCase);

--- a/test/SerializerTests/AuthenticationHeaderHandlerTests.cs
+++ b/test/SerializerTests/AuthenticationHeaderHandlerTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using System.Reflection;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using WasmApp.Services;
+
+namespace SerializerTests;
+
+// Tests must run serially because AuthenticationHeaderHandler uses a static redirect guard
+[DoNotParallelize]
+[TestClass]
+public sealed class AuthenticationHeaderHandlerTests
+{
+    private MockNavigationManager _navManager = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _navManager = new MockNavigationManager("https://localhost/timeline");
+
+        // Reset the static redirect guard between tests
+        var field = typeof(AuthenticationHeaderHandler)
+            .GetField("_isRedirecting", BindingFlags.NonPublic | BindingFlags.Static)!;
+        field.SetValue(null, 0);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_401_AnonymousUser_NavigatesHome()
+    {
+        var handler = CreateHandler(HttpStatusCode.Unauthorized, isAuthenticated: false);
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") };
+
+        await client.GetAsync("/api/something");
+
+        Assert.IsNotNull(_navManager.NavigatedTo, "Should navigate on 401");
+        StringAssert.StartsWith(_navManager.NavigatedTo, "/?returnUrl=",
+            "Anonymous user should be sent home, not to AAD");
+        Assert.IsFalse(_navManager.NavigatedTo!.Contains("/.auth/login/aad"),
+            "Should NOT redirect anonymous user to AAD login");
+        Assert.IsTrue(_navManager.ForceLoad, "Should use forceLoad=true");
+    }
+
+    [TestMethod]
+    public async Task SendAsync_401_AuthenticatedUser_NavigatesToAadForSilentReauth()
+    {
+        var handler = CreateHandler(HttpStatusCode.Unauthorized, isAuthenticated: true);
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") };
+
+        await client.GetAsync("/api/something");
+
+        Assert.IsNotNull(_navManager.NavigatedTo, "Should navigate on 401");
+        StringAssert.StartsWith(_navManager.NavigatedTo, "/.auth/login/aad?post_login_redirect_uri=",
+            "Session-expired authenticated user should be silently re-authed via AAD");
+        Assert.IsTrue(_navManager.ForceLoad, "Should use forceLoad=true");
+    }
+
+    [TestMethod]
+    public async Task SendAsync_401_ReturnUrlContainsCurrentUri()
+    {
+        var handler = CreateHandler(HttpStatusCode.Unauthorized, isAuthenticated: false);
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") };
+
+        await client.GetAsync("/api/something");
+
+        // The returnUrl should be the URL-encoded current page URI
+        var expectedEncoded = Uri.EscapeDataString("https://localhost/timeline");
+        Assert.IsTrue(_navManager.NavigatedTo!.Contains(expectedEncoded),
+            $"returnUrl should contain the current page URI. Got: {_navManager.NavigatedTo}");
+    }
+
+    [TestMethod]
+    public async Task SendAsync_200_DoesNotNavigate()
+    {
+        var handler = CreateHandler(HttpStatusCode.OK, isAuthenticated: false);
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") };
+
+        await client.GetAsync("/api/something");
+
+        Assert.IsNull(_navManager.NavigatedTo, "Should NOT navigate on a successful response");
+    }
+
+    [TestMethod]
+    public async Task SendAsync_401_DoubleRedirectGuard_NavigatesOnlyOnce()
+    {
+        // Two separate handler instances share the static _isRedirecting guard
+        var handler1 = CreateHandler(HttpStatusCode.Unauthorized, isAuthenticated: false);
+        var handler2 = CreateHandler(HttpStatusCode.Unauthorized, isAuthenticated: false);
+        var client1 = new HttpClient(handler1) { BaseAddress = new Uri("https://localhost/") };
+        var client2 = new HttpClient(handler2) { BaseAddress = new Uri("https://localhost/") };
+
+        await client1.GetAsync("/api/first");
+        var firstNav = _navManager.NavigatedTo;
+
+        // Reset capture so we can detect if a second navigation occurs
+        _navManager.NavigatedTo = null;
+        await client2.GetAsync("/api/second");
+
+        Assert.IsNotNull(firstNav, "First 401 should trigger navigation");
+        Assert.IsNull(_navManager.NavigatedTo, "Second 401 should be suppressed by the redirect guard");
+    }
+
+    // --- Helpers ---
+
+    private AuthenticationHeaderHandler CreateHandler(HttpStatusCode responseStatus, bool isAuthenticated)
+    {
+        var handler = new AuthenticationHeaderHandler(
+            new FakeAuthStateProvider(isAuthenticated),
+            _navManager)
+        {
+            InnerHandler = new FakeHttpMessageHandler(responseStatus)
+        };
+        return handler;
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        public FakeHttpMessageHandler(HttpStatusCode status) => _status = status;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(_status));
+    }
+
+    private sealed class FakeAuthStateProvider : AuthenticationStateProvider
+    {
+        private readonly bool _isAuthenticated;
+        public FakeAuthStateProvider(bool isAuthenticated) => _isAuthenticated = isAuthenticated;
+
+        public override Task<AuthenticationState> GetAuthenticationStateAsync()
+        {
+            var identity = _isAuthenticated
+                ? new ClaimsIdentity([new Claim(ClaimTypes.Name, "testuser")], "Test")
+                : new ClaimsIdentity();
+            return Task.FromResult(new AuthenticationState(new ClaimsPrincipal(identity)));
+        }
+    }
+
+    private sealed class MockNavigationManager : NavigationManager
+    {
+        public string? NavigatedTo { get; set; }
+        public bool ForceLoad { get; private set; }
+
+        public MockNavigationManager(string uri)
+        {
+            Initialize("https://localhost/", uri);
+        }
+
+        protected override void NavigateToCore(string uri, NavigationOptions options)
+        {
+            NavigatedTo = uri;
+            ForceLoad = options.ForceLoad;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

After clicking logout, users were silently re-authenticated and landed back on their timeline. Logout appeared broken.

## Root Cause (HAR-confirmed)

1. Browser served a **stale cached \/.auth/me\ response** post-logout (cookie already cleared)
2. \NavMenu\ called \POST /api/user/register\  got **401** (no valid session)
3. \AuthenticationHeaderHandler\ blindly redirected to \/.auth/login/aad\ on any 401
4. AAD session still valid  **silent SSO**  user re-authenticated

## Fix

**\AuthenticationStateProvider\**: Added \BrowserRequestCache.NoStore\ to the \/.auth/me\ request. Prevents browser from serving stale auth state after logout.

**\AuthenticationHeaderHandler\**: On 401, re-checks fresh auth state before redirecting:
- **Anonymous** (post-logout)  navigate to \/?returnUrl=...\ (home page)  
- **Authenticated** (session expiry)  keep existing AAD silent re-auth behavior

Also tightens the double-redirect guard: \static volatile bool\  \static int\ + \Interlocked.CompareExchange\.

## Tests

5 new unit tests in \AuthenticationHeaderHandlerTests\:
- Anonymous 401  navigates home (not to AAD)
- Authenticated 401  navigates to AAD for silent re-auth
- 200 response  no navigation
- \eturnUrl\ contains current page URI
- Double-redirect guard fires only once

> Note: The full logout flow requires Entra auth and can only be verified in production.