### PR TITLE
refactor: introduce IDbConnections provider for SQLite read/write split

### DIFF
--- a/src/Server/Data/IDbConnections.cs
+++ b/src/Server/Data/IDbConnections.cs
@@ -1,0 +1,10 @@
+namespace RssApp.Data;
+using Microsoft.Data.Sqlite;
+
+public interface IDbConnections
+{
+    SqliteConnection OpenRead();
+    Task<SqliteConnection> OpenReadAsync();
+    SqliteConnection OpenWrite();              // throws InvalidOperationException in replica mode
+    Task<SqliteConnection> OpenWriteAsync();   // throws InvalidOperationException in replica mode
+}

--- a/src/Server/Data/RepositoryFactory.cs
+++ b/src/Server/Data/RepositoryFactory.cs
@@ -1,4 +1,3 @@
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using RssApp.Contracts;
 using RssReader.Server.Services;
@@ -7,21 +6,18 @@ namespace RssApp.Data;
 
 public class RepositoryFactory
 {
-    private readonly string writeConnectionString;
-    private readonly string readConnectionString;
+    private readonly IDbConnections connections;
     private readonly IServiceProvider serviceProvider;
     private readonly bool isReadOnly;
     private readonly bool rebuildFtsOnStartup;
 
     public RepositoryFactory(
-        string writeConnectionString,
-        string readConnectionString,
+        IDbConnections connections,
         IServiceProvider serviceProvider,
         bool isReadOnly = false,
         bool rebuildFtsOnStartup = false)
     {
-        this.writeConnectionString = writeConnectionString;
-        this.readConnectionString = readConnectionString;
+        this.connections = connections;
         this.serviceProvider = serviceProvider;
         this.isReadOnly = isReadOnly;
         this.rebuildFtsOnStartup = rebuildFtsOnStartup;
@@ -30,24 +26,23 @@ public class RepositoryFactory
     public IUserRepository CreateUserRepository()
     {
         return new SQLiteUserRepository(
-            this.writeConnectionString,
-            this.readConnectionString,
-            this.serviceProvider.GetRequiredService<ILogger<SQLiteUserRepository>>());
+            this.connections,
+            this.serviceProvider.GetRequiredService<ILogger<SQLiteUserRepository>>(),
+            this.isReadOnly);
     }
 
     public IFeedRepository CreateFeedRepository()
     {
         return new SQLiteFeedRepository(
-            this.writeConnectionString,
-            this.readConnectionString,
-            this.serviceProvider.GetRequiredService<ILogger<SQLiteFeedRepository>>());
+            this.connections,
+            this.serviceProvider.GetRequiredService<ILogger<SQLiteFeedRepository>>(),
+            this.isReadOnly);
     }
 
     public IItemRepository CreateItemRepository()
     {
         return new SQLiteItemRepository(
-            this.writeConnectionString,
-            this.readConnectionString,
+            this.connections,
             this.serviceProvider.GetRequiredService<ILogger<SQLiteItemRepository>>(),
             this.serviceProvider.GetRequiredService<IFeedRepository>(),
             this.serviceProvider.GetRequiredService<IUserRepository>(),

--- a/src/Server/Data/SQLiteFeedRepository.cs
+++ b/src/Server/Data/SQLiteFeedRepository.cs
@@ -6,29 +6,24 @@ namespace RssApp.Data;
 
 public class SQLiteFeedRepository : IFeedRepository
 {
-    private readonly string writeConnectionString;
-    private readonly string readConnectionString;
+    private readonly IDbConnections connections;
     private readonly ILogger<SQLiteFeedRepository> logger;
 
     public SQLiteFeedRepository(
-        string writeConnectionString,
-        string readConnectionString,
+        IDbConnections connections,
         ILogger<SQLiteFeedRepository> logger,
         bool isReadOnly = false)
     {
-        this.writeConnectionString = writeConnectionString;
-        this.readConnectionString = readConnectionString;
+        this.connections = connections;
         this.logger = logger;
         if (!isReadOnly) this.InitializeDatabase();
     }
 
     private void InitializeDatabase()
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
-
-            // WAL mode is persistent — only needs to be set once per database file.
+            // WAL mode is persistent  only needs to be set once per database file.
             var walCmd = connection.CreateCommand();
             walCmd.CommandText = "PRAGMA journal_mode=WAL;";
             walCmd.ExecuteNonQuery();
@@ -63,9 +58,8 @@ public class SQLiteFeedRepository : IFeedRepository
     {
         var feeds = new HashSet<NewsFeed>();
 
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = """
                 SELECT f.Id, f.Url, f.UserId, f.IsPaywalled, f.Tags FROM Feeds f
@@ -93,9 +87,8 @@ public class SQLiteFeedRepository : IFeedRepository
     {
         var feeds = new HashSet<NewsFeed>();
 
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = """
                 SELECT f.Id, f.Url, f.UserId, f.IsPaywalled, f.Tags FROM Feeds f
@@ -125,9 +118,8 @@ public class SQLiteFeedRepository : IFeedRepository
     {
         try
         {
-            using (var connection = new SqliteConnection(this.writeConnectionString))
+            using (var connection = this.connections.OpenWrite())
             {
-                connection.OpenWithWritePragmas();
                 var command = connection.CreateCommand();
                 command.CommandText = "INSERT INTO Feeds (Url, UserId) VALUES (@url, @userId)";
                 command.Parameters.AddWithValue("@url", feed.Href);
@@ -143,9 +135,8 @@ public class SQLiteFeedRepository : IFeedRepository
         catch (SqliteException ex) when (ex.SqliteErrorCode == 19 && ex.Message.Contains("UNIQUE"))
         {
             // Feed already exists, just update the ID
-            using (var connection = new SqliteConnection(this.readConnectionString))
+            using (var connection = this.connections.OpenRead())
             {
-                connection.OpenWithReadPragmas();
                 var command = connection.CreateCommand();
                 command.CommandText = "SELECT Id FROM Feeds WHERE Url = @url AND UserId = @userId";
                 command.Parameters.AddWithValue("@url", feed.Href);
@@ -164,9 +155,8 @@ public class SQLiteFeedRepository : IFeedRepository
 
     public string GetTagsByFeedId(int feedId)
     {
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = "SELECT Tags FROM Feeds WHERE Id = @feedId";
             command.Parameters.AddWithValue("@feedId", feedId);
@@ -197,9 +187,8 @@ public class SQLiteFeedRepository : IFeedRepository
 
         existing.Add(tag);
 
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = "UPDATE Feeds SET Tags = @tags WHERE Id = @feedId AND UserId = @userId";
             command.Parameters.AddWithValue("@feedId", feed.FeedId);
@@ -220,8 +209,7 @@ public class SQLiteFeedRepository : IFeedRepository
         var existingFeeds = GetFeeds(user).ToList();
         var existingUrls = existingFeeds.Select(f => f.Href).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        using var connection = new SqliteConnection(this.writeConnectionString);
-        connection.OpenWithWritePragmas();
+        using var connection = this.connections.OpenWrite();
         using var transaction = connection.BeginTransaction();
 
         foreach (var feed in feeds)
@@ -285,9 +273,8 @@ public class SQLiteFeedRepository : IFeedRepository
 
     public void DeleteFeed(RssUser user, string url)
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = """
                 DELETE FROM Feeds
@@ -309,9 +296,8 @@ public class SQLiteFeedRepository : IFeedRepository
 
         var hiddenTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = "SELECT Tag FROM UserTagSettings WHERE UserId = @userId AND IsHidden = 1";
             command.Parameters.AddWithValue("@userId", user.Id);
@@ -333,9 +319,8 @@ public class SQLiteFeedRepository : IFeedRepository
 
     public void SetTagHidden(RssUser user, string tag, bool isHidden)
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = @"
                 INSERT INTO UserTagSettings (UserId, Tag, IsHidden)
@@ -352,9 +337,8 @@ public class SQLiteFeedRepository : IFeedRepository
     {
         var hiddenTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = "SELECT Tag FROM UserTagSettings WHERE UserId = @userId AND IsHidden = 1";
             command.Parameters.AddWithValue("@userId", user.Id);
@@ -380,8 +364,7 @@ public class SQLiteFeedRepository : IFeedRepository
 
     public void DeleteAllFeeds(RssUser user)
     {
-        using var connection = new SqliteConnection(this.writeConnectionString);
-        connection.OpenWithWritePragmas();
+        using var connection = this.connections.OpenWrite();
         using var transaction = connection.BeginTransaction();
 
         var cmd = connection.CreateCommand();

--- a/src/Server/Data/SQLiteItemRepository.cs
+++ b/src/Server/Data/SQLiteItemRepository.cs
@@ -8,20 +8,18 @@ namespace RssApp.Data;
 
 public class SQLiteItemRepository : IItemRepository, IDisposable
 {
-    private readonly string writeConnectionString;
-    private readonly string readConnectionString;
+    private readonly IDbConnections connections;
     private readonly ILogger<SQLiteItemRepository> logger;
     private readonly IFeedRepository feedStore;
     private readonly IUserRepository userStore;
     private readonly FeedThumbnailRetriever feedThumbnailRetriever;
 
-    // Serialize writes — SQLite allows only one writer at a time.
+    // Serialize writes  SQLite allows only one writer at a time.
     private readonly SemaphoreSlim writeSemaphore = new SemaphoreSlim(1, 1);
     private readonly bool rebuildFtsOnStartup;
 
     public SQLiteItemRepository(
-        string writeConnectionString,
-        string readConnectionString,
+        IDbConnections connections,
         ILogger<SQLiteItemRepository> logger,
         IFeedRepository feedStore,
         IUserRepository userStore,
@@ -29,8 +27,7 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
         bool isReadOnly = false,
         bool rebuildFtsOnStartup = false)
     {
-        this.writeConnectionString = writeConnectionString;
-        this.readConnectionString = readConnectionString;
+        this.connections = connections;
         this.logger = logger;
         this.feedStore = feedStore;
         this.userStore = userStore;
@@ -41,11 +38,9 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     private void InitializeDatabase()
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
-
-            // WAL mode is persistent — only needs to be set once per database file.
+            // WAL mode is persistent  only needs to be set once per database file.
             var walCmd = connection.CreateCommand();
             walCmd.CommandText = "PRAGMA journal_mode=WAL;";
             walCmd.ExecuteNonQuery();
@@ -121,7 +116,7 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
                 }
                 catch (SqliteException ex) when (ex.SqliteErrorCode == 11) // SQLITE_CORRUPT
                 {
-                    logger.LogWarning(ex, "FTS5 index corrupt — dropping and recreating");
+                    logger.LogWarning(ex, "FTS5 index corrupt  dropping and recreating");
                     command = connection.CreateCommand();
                     command.CommandText = @"DROP TABLE IF EXISTS Items_fts;";
                     command.ExecuteNonQuery();
@@ -179,7 +174,7 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
                 END;";
             command.ExecuteNonQuery();
 
-            // Index for timeline ORDER BY + cursor pagination — eliminates full-table scan + sort
+            // Index for timeline ORDER BY + cursor pagination  eliminates full-table scan + sort
             command = connection.CreateCommand();
             command.CommandText = @"
                 CREATE INDEX IF NOT EXISTS idx_items_timeline
@@ -205,9 +200,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
     {
         var set = new HashSet<NewsFeedItem>();
 
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = await this.connections.OpenReadAsync())
         {
-            await connection.OpenWithReadPragmasAsync();
             var command = connection.CreateCommand();
             command.CommandText = """
                 SELECT
@@ -254,9 +248,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
     {
         var set = new HashSet<NewsFeedItem>();
 
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = await this.connections.OpenReadAsync())
         {
-            await connection.OpenWithReadPragmasAsync();
             var command = connection.CreateCommand();
             command.CommandText = """
                 SELECT
@@ -329,9 +322,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
         var items = new List<NewsFeedItem>();
         var user = this.userStore.GetUserById(feed.UserId);
 
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = await this.connections.OpenReadAsync())
         {
-            await connection.OpenWithReadPragmasAsync();
             var command = connection.CreateCommand();
 
             var contentColumn = includeContent ? "ic.Content" : "NULL AS Content";
@@ -468,9 +460,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     public NewsFeedItem GetItem(RssUser user, string href)
     {
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = """
                 SELECT * FROM Items
@@ -495,9 +486,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     public NewsFeedItem GetItem(RssUser user, int itemId)
     {
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = """
                 SELECT * FROM Items
@@ -522,9 +512,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     public string GetItemContent(NewsFeedItem item)
     {
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = @"
                 SELECT Content 
@@ -591,8 +580,7 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
             if (preparedItems.Count == 0) return;
 
             // Phase 2: Single connection + transaction for all DB writes
-            using var connection = new SqliteConnection(this.writeConnectionString);
-            await connection.OpenWithWritePragmasAsync();
+            using var connection = await this.connections.OpenWriteAsync();
             using var transaction = connection.BeginTransaction();
 
             foreach (var item in preparedItems)
@@ -660,9 +648,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     public void UpdateTags(NewsFeedItem item, string tags)
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = @"
                 UPDATE Items
@@ -678,9 +665,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     public void MarkAsRead(NewsFeedItem item, bool isRead, RssUser user)
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = @"
                 UPDATE Items
@@ -696,9 +682,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     public void SavePost(NewsFeedItem item, RssUser user)
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = @"
                 UPDATE Items
@@ -713,9 +698,8 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     public void UnsavePost(NewsFeedItem item, RssUser user)
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = @"
                 UPDATE Items
@@ -730,8 +714,7 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     public async Task DeleteAllItemsAsync(RssUser user)
     {
-        using var connection = new SqliteConnection(this.writeConnectionString);
-        await connection.OpenWithWritePragmasAsync();
+        using var connection = await this.connections.OpenWriteAsync();
         using var transaction = connection.BeginTransaction();
 
         var command = connection.CreateCommand();
@@ -750,8 +733,7 @@ public class SQLiteItemRepository : IItemRepository, IDisposable
 
     public int GetItemCountForFeed(RssUser user, string feedUrl)
     {
-        using var connection = new SqliteConnection(this.readConnectionString);
-        connection.OpenWithReadPragmas();
+        using var connection = this.connections.OpenRead();
         var command = connection.CreateCommand();
         command.CommandText = "SELECT COUNT(*) FROM Items WHERE UserId = @userId AND FeedUrl = @feedUrl";
         command.Parameters.AddWithValue("@userId", user.Id);

--- a/src/Server/Data/SQLiteSystemStatsRepository.cs
+++ b/src/Server/Data/SQLiteSystemStatsRepository.cs
@@ -5,18 +5,17 @@ namespace RssApp.Data;
 
 public class SQLiteSystemStatsRepository : ISystemStatsRepository
 {
-    private readonly string _connectionString;
+    private readonly IDbConnections _connections;
 
-    public SQLiteSystemStatsRepository(string connectionString)
+    public SQLiteSystemStatsRepository(IDbConnections connections)
     {
-        _connectionString = connectionString;
+        _connections = connections;
         InitializeDatabase();
     }
 
     private void InitializeDatabase()
     {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.OpenWithPragmas();
+        using var connection = _connections.OpenWrite();
 
         var pragmaCmd = connection.CreateCommand();
         pragmaCmd.CommandText = @"
@@ -42,8 +41,7 @@ public class SQLiteSystemStatsRepository : ISystemStatsRepository
 
     public void RecordSnapshot(SystemStatsSnapshot snapshot)
     {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.OpenWithPragmas();
+        using var connection = _connections.OpenWrite();
 
         var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -59,8 +57,7 @@ public class SQLiteSystemStatsRepository : ISystemStatsRepository
 
     public SystemStatsSnapshot GetLatestSnapshot()
     {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.OpenWithPragmas();
+        using var connection = _connections.OpenRead();
 
         var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -78,8 +75,7 @@ public class SQLiteSystemStatsRepository : ISystemStatsRepository
 
     public IEnumerable<SystemStatsSnapshot> GetHistory(int days = 30)
     {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.OpenWithPragmas();
+        using var connection = _connections.OpenRead();
 
         var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -100,8 +96,7 @@ public class SQLiteSystemStatsRepository : ISystemStatsRepository
 
     public void CleanupOlderThan(int days = 30)
     {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.OpenWithPragmas();
+        using var connection = _connections.OpenWrite();
 
         var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -124,3 +119,4 @@ public class SQLiteSystemStatsRepository : ISystemStatsRepository
         };
     }
 }
+

--- a/src/Server/Data/SQLiteUserRepository.cs
+++ b/src/Server/Data/SQLiteUserRepository.cs
@@ -6,29 +6,24 @@ namespace RssApp.Data;
 
 public class SQLiteUserRepository : IUserRepository
 {
-    private readonly string writeConnectionString;
-    private readonly string readConnectionString;
+    private readonly IDbConnections connections;
     private readonly ILogger<SQLiteUserRepository> logger;
 
     public SQLiteUserRepository(
-        string writeConnectionString,
-        string readConnectionString,
+        IDbConnections connections,
         ILogger<SQLiteUserRepository> logger,
         bool isReadOnly = false)
     {
-        this.writeConnectionString = writeConnectionString;
-        this.readConnectionString = readConnectionString;
+        this.connections = connections;
         this.logger = logger;
         if (!isReadOnly) this.InitializeDatabase();
     }
 
     private void InitializeDatabase()
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
-
-            // WAL mode is persistent — only needs to be set once per database file.
+            // WAL mode is persistent  only needs to be set once per database file.
             var walCmd = connection.CreateCommand();
             walCmd.CommandText = "PRAGMA journal_mode=WAL;";
             walCmd.ExecuteNonQuery();
@@ -65,9 +60,8 @@ public class SQLiteUserRepository : IUserRepository
 
     public RssUser GetUserByName(string username)
     {
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = "SELECT * FROM Users WHERE Username = @username";
             command.Parameters.AddWithValue("@username", username);
@@ -86,9 +80,8 @@ public class SQLiteUserRepository : IUserRepository
 
     public RssUser GetUserById(int userId)
     {
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = "SELECT * FROM Users WHERE Id = @userId";
             command.Parameters.AddWithValue("@userId", userId);
@@ -108,9 +101,8 @@ public class SQLiteUserRepository : IUserRepository
 
     public RssUser GetUserByAadId(string aadUserId)
     {
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = "SELECT * FROM Users WHERE AadUserId = @aadUserId";
             command.Parameters.AddWithValue("@aadUserId", aadUserId);
@@ -129,9 +121,8 @@ public class SQLiteUserRepository : IUserRepository
 
     public void SetAadUserId(int userId, string aadUserId)
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = "UPDATE Users SET AadUserId = @aadUserId WHERE Id = @userId";
             command.Parameters.AddWithValue("@aadUserId", aadUserId);
@@ -142,9 +133,8 @@ public class SQLiteUserRepository : IUserRepository
 
     public void UpdateUsername(int userId, string newUsername)
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = "UPDATE Users SET Username = @newUsername WHERE Id = @userId";
             command.Parameters.AddWithValue("@newUsername", newUsername);
@@ -155,9 +145,8 @@ public class SQLiteUserRepository : IUserRepository
 
     public RssUser AddUser(string username, int? id = null)
     {
-        using (var connection = new SqliteConnection(this.writeConnectionString))
+        using (var connection = this.connections.OpenWrite())
         {
-            connection.OpenWithWritePragmas();
             var command = connection.CreateCommand();
             command.CommandText = "INSERT INTO Users (Username";
             if (id.HasValue)
@@ -181,9 +170,8 @@ public class SQLiteUserRepository : IUserRepository
 
     public IEnumerable<RssUser> GetAllUsers()
     {
-        using (var connection = new SqliteConnection(this.readConnectionString))
+        using (var connection = this.connections.OpenRead())
         {
-            connection.OpenWithReadPragmas();
             var command = connection.CreateCommand();
             command.CommandText = "SELECT * FROM Users";
 
@@ -200,8 +188,7 @@ public class SQLiteUserRepository : IUserRepository
 
     public void DeleteUser(int userId)
     {
-        using var connection = new SqliteConnection(this.writeConnectionString);
-        connection.OpenWithWritePragmas();
+        using var connection = this.connections.OpenWrite();
         var command = connection.CreateCommand();
         command.CommandText = "DELETE FROM Users WHERE Id = @userId";
         command.Parameters.AddWithValue("@userId", userId);

--- a/src/Server/Data/SqliteConnectionExtensions.cs
+++ b/src/Server/Data/SqliteConnectionExtensions.cs
@@ -3,36 +3,10 @@ using Microsoft.Data.Sqlite;
 namespace RssApp.Data;
 
 /// <summary>
-/// Controls whether new SQLite connections are opened with PRAGMA query_only = ON.
-/// Set once at startup after schema initialization; never changed afterward.
-/// </summary>
-public static class DatabaseMode
-{
-    public static bool QueryOnly { get; private set; }
-
-    /// <summary>
-    /// Enable query_only mode for all subsequent connections opened via
-    /// <see cref="SqliteConnectionExtensions.OpenWithPragmas"/>.
-    /// Call this AFTER schema initialization (CREATE TABLE) has completed.
-    /// </summary>
-    public static void EnableQueryOnly()
-    {
-        QueryOnly = true;
-    }
-
-    /// <summary>
-    /// Reset for testing only. Not intended for production use.
-    /// </summary>
-    internal static void ResetForTesting()
-    {
-        QueryOnly = false;
-    }
-}
-
-/// <summary>
 /// Sets per-connection PRAGMAs that must be applied to every pooled connection.
 /// With Pooling=True, new physical connections start with default PRAGMAs.
 /// Calling this after every Open() ensures consistent behavior.
+/// Used internally by <see cref="SqliteDbConnections"/>.
 /// </summary>
 internal static class SqliteConnectionExtensions
 {
@@ -56,7 +30,6 @@ internal static class SqliteConnectionExtensions
         using var cmd = connection.CreateCommand();
         cmd.CommandText = ReadPragmas;
         cmd.ExecuteNonQuery();
-        ApplyQueryOnly(connection);
     }
 
     public static async Task OpenWithReadPragmasAsync(this SqliteConnection connection)
@@ -65,7 +38,6 @@ internal static class SqliteConnectionExtensions
         using var cmd = connection.CreateCommand();
         cmd.CommandText = ReadPragmas;
         await cmd.ExecuteNonQueryAsync();
-        await ApplyQueryOnlyAsync(connection);
     }
 
     public static void OpenWithWritePragmas(this SqliteConnection connection)
@@ -74,9 +46,6 @@ internal static class SqliteConnectionExtensions
         using var cmd = connection.CreateCommand();
         cmd.CommandText = WritePragmas;
         cmd.ExecuteNonQuery();
-        // DB-level backstop: if DatabaseMode.QueryOnly is set (read-replica mode),
-        // reject writes even on connections that were opened with write intent.
-        ApplyQueryOnly(connection);
     }
 
     public static async Task OpenWithWritePragmasAsync(this SqliteConnection connection)
@@ -84,56 +53,6 @@ internal static class SqliteConnectionExtensions
         await connection.OpenAsync();
         using var cmd = connection.CreateCommand();
         cmd.CommandText = WritePragmas;
-        await cmd.ExecuteNonQueryAsync();
-        // DB-level backstop: if DatabaseMode.QueryOnly is set (read-replica mode),
-        // reject writes even on connections that were opened with write intent.
-        await ApplyQueryOnlyAsync(connection);
-    }
-
-    /// <summary>
-    /// Opens the connection and applies per-connection PRAGMAs.
-    /// Delegates to <see cref="OpenWithReadPragmas"/> or <see cref="OpenWithWritePragmas"/>
-    /// based on whether the connection string contains Mode=ReadOnly.
-    /// <para>
-    /// Used by services that receive a pre-chosen connection string (e.g. SQLiteSystemStatsRepository)
-    /// and don't explicitly call the read/write variants. Both variants already enforce
-    /// <see cref="DatabaseMode.QueryOnly"/> as a DB-level backstop.
-    /// </para>
-    /// </summary>
-    public static void OpenWithPragmas(this SqliteConnection connection)
-    {
-        var isReadOnly = connection.ConnectionString?.Contains("Mode=ReadOnly", StringComparison.OrdinalIgnoreCase) == true;
-        if (isReadOnly)
-            connection.OpenWithReadPragmas();
-        else
-            connection.OpenWithWritePragmas();
-    }
-
-    /// <summary>
-    /// Async version of <see cref="OpenWithPragmas"/>.
-    /// </summary>
-    public static async Task OpenWithPragmasAsync(this SqliteConnection connection)
-    {
-        var isReadOnly = connection.ConnectionString?.Contains("Mode=ReadOnly", StringComparison.OrdinalIgnoreCase) == true;
-        if (isReadOnly)
-            await connection.OpenWithReadPragmasAsync();
-        else
-            await connection.OpenWithWritePragmasAsync();
-    }
-
-    private static void ApplyQueryOnly(SqliteConnection connection)
-    {
-        if (!DatabaseMode.QueryOnly) return;
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = "PRAGMA query_only = ON";
-        cmd.ExecuteNonQuery();
-    }
-
-    private static async Task ApplyQueryOnlyAsync(SqliteConnection connection)
-    {
-        if (!DatabaseMode.QueryOnly) return;
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = "PRAGMA query_only = ON";
         await cmd.ExecuteNonQueryAsync();
     }
 }

--- a/src/Server/Data/SqliteDbConnections.cs
+++ b/src/Server/Data/SqliteDbConnections.cs
@@ -1,0 +1,55 @@
+namespace RssApp.Data;
+using Microsoft.Data.Sqlite;
+
+/// <summary>
+/// Owns the SQLite connection-string and pragma logic for a single database file.
+/// Replaces the two-string (write/read) ceremony that was scattered across every repository.
+/// In read-replica mode (<paramref name="isReadOnly"/> = true), <see cref="OpenWrite"/> and
+/// <see cref="OpenWriteAsync"/> throw <see cref="InvalidOperationException"/> instead of
+/// handing out a writable connection.
+/// </summary>
+public sealed class SqliteDbConnections : IDbConnections
+{
+    private readonly string _readString;
+    private readonly string _writeString;
+    private readonly bool _isReadOnly;
+
+    public SqliteDbConnections(string dbLocation, bool isReadOnly)
+    {
+        _isReadOnly = isReadOnly;
+        _readString  = $"Data Source={dbLocation};Mode=ReadOnly;Pooling=True";
+        _writeString = $"Data Source={dbLocation};Mode=ReadWriteCreate;Cache=Shared;Pooling=True";
+    }
+
+    public SqliteConnection OpenRead()
+    {
+        var conn = new SqliteConnection(_readString);
+        conn.OpenWithReadPragmas();
+        return conn;
+    }
+
+    public async Task<SqliteConnection> OpenReadAsync()
+    {
+        var conn = new SqliteConnection(_readString);
+        await conn.OpenWithReadPragmasAsync();
+        return conn;
+    }
+
+    public SqliteConnection OpenWrite()
+    {
+        if (_isReadOnly)
+            throw new InvalidOperationException("Cannot open write connection in read-replica mode.");
+        var conn = new SqliteConnection(_writeString);
+        conn.OpenWithWritePragmas();
+        return conn;
+    }
+
+    public async Task<SqliteConnection> OpenWriteAsync()
+    {
+        if (_isReadOnly)
+            throw new InvalidOperationException("Cannot open write connection in read-replica mode.");
+        var conn = new SqliteConnection(_writeString);
+        await conn.OpenWithWritePragmasAsync();
+        return conn;
+    }
+}

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -16,13 +16,7 @@ builder.Configuration
     .AddJsonFile("appsettings.Development.json", optional: true)
     .AddEnvironmentVariables();
 var config = RssAppConfig.LoadFromAppSettings(builder.Configuration);
-// Separate read/write connection strings for WAL concurrency.
-// Read connections use Mode=ReadOnly to avoid SQLite WAL/SHM conflicts with Litestream follow mode.
-// Write connections use ReadWriteCreate with Cache=Shared for normal operation.
-string dbWriteConnectionString = $"Data Source={config.DbLocation};Mode=ReadWriteCreate;Cache=Shared;Pooling=True";
-string dbReadConnectionString = $"Data Source={config.DbLocation};Mode=ReadOnly;Pooling=True";
-// dbConnectionString is used for services that don't need read/write split (e.g. stats, backup)
-string dbConnectionString = config.IsReadOnly ? dbReadConnectionString : dbWriteConnectionString;
+var dbConnections = new SqliteDbConnections(config.DbLocation, config.IsReadOnly);
 
 builder.WebHost.ConfigureKestrel(serverOptions =>
 {
@@ -71,7 +65,8 @@ builder.Services
 // Creation order matters — feed and user repos must exist before item repo.
 builder.Services
     .AddSingleton<RssAppConfig>(_ => config)
-    .AddSingleton<RepositoryFactory>(sb => new RepositoryFactory(dbWriteConnectionString, dbReadConnectionString, sb, config.IsReadOnly, config.RebuildFtsOnStartup))
+    .AddSingleton<IDbConnections>(_ => dbConnections)
+    .AddSingleton<RepositoryFactory>(sb => new RepositoryFactory(dbConnections, sb, config.IsReadOnly, config.RebuildFtsOnStartup))
     .AddSingleton<IFeedRepository>(sb =>
     {
         var inner = sb.GetRequiredService<RepositoryFactory>().CreateFeedRepository();
@@ -90,7 +85,7 @@ builder.Services
     .AddSingleton<IUserResolver, UserResolver>()
     .AddSingleton<FeedThumbnailRetriever>()
     .AddSingleton<ISystemStatsRepository>(sb =>
-        new SQLiteSystemStatsRepository(dbConnectionString));
+        new SQLiteSystemStatsRepository(dbConnections));
 
 if (!config.IsReadOnly)
 {
@@ -149,14 +144,6 @@ var a = app.Services.GetRequiredService<IFeedRepository>();
 var b = app.Services.GetRequiredService<IUserRepository>();
 var c = app.Services.GetRequiredService<IItemRepository>();
 var d = app.Services.GetRequiredService<ISystemStatsRepository>();
-
-// After schema init (writer) or startup (reader), enable PRAGMA query_only
-// on all subsequent connections. This is the DB-level backstop — even if a
-// write request bypasses the HTTP filter, SQLite will reject the mutation.
-if (config.IsReadOnly)
-{
-    DatabaseMode.EnableQueryOnly();
-}
 
 // Enable middleware 
 app.UseHttpsRedirection();

--- a/test/SerializerTests/AccountTests.cs
+++ b/test/SerializerTests/AccountTests.cs
@@ -11,7 +11,6 @@ using RssReader.Server.Services;
 public sealed class AccountTests
 {
     private string testDbFile;
-    private string connectionString;
 
     private SQLiteUserRepository userRepo;
     private SQLiteFeedRepository feedRepo;
@@ -22,7 +21,7 @@ public sealed class AccountTests
     public void Setup()
     {
         testDbFile = $"account-{Guid.NewGuid():N}.db";
-        connectionString = $"Data Source={testDbFile}";
+        var dbConnections = new SqliteDbConnections(testDbFile, isReadOnly: false);
 
         Directory.CreateDirectory(Path.Combine("wwwroot", "images"));
         // Pre-create favicon to skip network download in AddItemsAsync
@@ -34,8 +33,8 @@ public sealed class AccountTests
         }
         catch (Exception) { /* ignore — another parallel test may be writing it */ }
 
-        userRepo = new SQLiteUserRepository(connectionString, connectionString, new NullLogger<SQLiteUserRepository>());
-        feedRepo = new SQLiteFeedRepository(connectionString, connectionString, new NullLogger<SQLiteFeedRepository>());
+        userRepo = new SQLiteUserRepository(dbConnections, new NullLogger<SQLiteUserRepository>());
+        feedRepo = new SQLiteFeedRepository(dbConnections, new NullLogger<SQLiteFeedRepository>());
 
         var serviceCollection = new ServiceCollection();
         serviceCollection
@@ -46,8 +45,7 @@ public sealed class AccountTests
             .AddSingleton<IUserRepository>(userRepo)
             .AddSingleton<IItemRepository>(sb =>
                 new SQLiteItemRepository(
-                    connectionString,
-                    connectionString,
+                    dbConnections,
                     sb.GetRequiredService<ILogger<SQLiteItemRepository>>(),
                     sb.GetRequiredService<IFeedRepository>(),
                     sb.GetRequiredService<IUserRepository>(),

--- a/test/SerializerTests/AdminTests.cs
+++ b/test/SerializerTests/AdminTests.cs
@@ -95,7 +95,7 @@ public sealed class AdminTests
     // ── stats recording and retrieval ─────────────────────────────────────────
 
     private SQLiteSystemStatsRepository CreateRepo(string db)
-        => new SQLiteSystemStatsRepository($"Data Source={db}");
+        => new SQLiteSystemStatsRepository(new SqliteDbConnections(db, isReadOnly: false));
 
     [TestMethod]
     public void RecordSnapshot_ThenGetLatest_ReturnsCorrectData()

--- a/test/SerializerTests/ItemRepoTests.cs
+++ b/test/SerializerTests/ItemRepoTests.cs
@@ -26,15 +26,14 @@ public sealed class ItemRepoTests
         Directory.CreateDirectory(Path.Combine("wwwroot", "images"));
 
         var config = new RssAppConfig { DbLocation = "tests.db" };
+        var dbConnections = new SqliteDbConnections("tests.db", isReadOnly: false);
 
         var userRepo = new SQLiteUserRepository(
-            $"Data Source=tests.db;Pooling=True",
-            $"Data Source=tests.db;Mode=ReadOnly;Pooling=True",
+            dbConnections,
             new NullLogger<SQLiteUserRepository>());
         userRepo.AddUser("testUser", 0);
         var feedRepo = new SQLiteFeedRepository(
-            $"Data Source=tests.db;Pooling=True",
-            $"Data Source=tests.db;Mode=ReadOnly;Pooling=True",
+            dbConnections,
             new NullLogger<SQLiteFeedRepository>());
         feedRepo.AddFeed(new NewsFeed(1, "https://feeds.propublica.org/propublica/main", 0));
 
@@ -62,8 +61,7 @@ public sealed class ItemRepoTests
         .AddSingleton<IItemRepository>(sb =>
         {
             return new SQLiteItemRepository(
-                $"Data Source=tests.db;Pooling=True",
-                $"Data Source=tests.db;Mode=ReadOnly;Pooling=True",
+                dbConnections,
                 sb.GetRequiredService<ILogger<SQLiteItemRepository>>(),
                 sb.GetRequiredService<IFeedRepository>(),
                 sb.GetRequiredService<IUserRepository>(),
@@ -133,10 +131,10 @@ public sealed class ItemRepoTests
         if (File.Exists(dbName)) File.Delete(dbName);
         Directory.CreateDirectory(Path.Combine("wwwroot", "images"));
 
-        var connStr = $"Data Source={dbName}";
-        var userRepo = new SQLiteUserRepository(connStr, connStr, new NullLogger<SQLiteUserRepository>());
+        var dbConnections = new SqliteDbConnections(dbName, isReadOnly: false);
+        var userRepo = new SQLiteUserRepository(dbConnections, new NullLogger<SQLiteUserRepository>());
         userRepo.AddUser("testUser", 0);
-        var feedRepo = new SQLiteFeedRepository(connStr, connStr, new NullLogger<SQLiteFeedRepository>());
+        var feedRepo = new SQLiteFeedRepository(dbConnections, new NullLogger<SQLiteFeedRepository>());
         var feed = new NewsFeed(1, "https://feeds.example.org/test", 0);
         feedRepo.AddFeed(feed);
 
@@ -151,8 +149,7 @@ public sealed class ItemRepoTests
             .AddSingleton<IUserRepository>(userRepo)
             .AddSingleton<IItemRepository>(sb =>
                 new SQLiteItemRepository(
-                    connStr,
-                    connStr,
+                    dbConnections,
                     sb.GetRequiredService<ILogger<SQLiteItemRepository>>(),
                     sb.GetRequiredService<IFeedRepository>(),
                     sb.GetRequiredService<IUserRepository>(),

--- a/test/SerializerTests/ReadOnlyModeTests.cs
+++ b/test/SerializerTests/ReadOnlyModeTests.cs
@@ -15,12 +15,6 @@ using RssApp.Filters;
 [TestClass]
 public sealed class ReadOnlyModeTests
 {
-    [TestCleanup]
-    public void Cleanup()
-    {
-        DatabaseMode.ResetForTesting();
-    }
-
     [TestMethod]
     public void IsReadOnly_DefaultsToFalse()
     {
@@ -134,108 +128,76 @@ public sealed class ReadOnlyModeTests
     }
 
     // ========================================================================
-    // PRAGMA query_only tests (DB-level backstop)
+    // IDbConnections read-replica enforcement tests
     // ========================================================================
 
     [TestMethod]
-    public void QueryOnly_RejectsInsert_AfterEnabled()
+    public void IDbConnections_OpenWrite_ThrowsInvalidOperationException_WhenReadOnly()
     {
         var dbPath = $"readonly_test_{Guid.NewGuid():N}.db";
         try
         {
-            var connStr = $"Data Source={dbPath};Mode=ReadWriteCreate";
-
-            // Create a table while query_only is off
-            using (var conn = new SqliteConnection(connStr))
+            // Seed the DB file so ReadOnly mode can open it
+            var writer = new SqliteDbConnections(dbPath, isReadOnly: false);
+            using (var conn = writer.OpenWrite())
             {
-                conn.Open();
-                using var cmd = conn.CreateCommand();
-                cmd.CommandText = "CREATE TABLE Test (Id INTEGER PRIMARY KEY, Value TEXT)";
-                cmd.ExecuteNonQuery();
-            }
-
-            // Now open with query_only = ON and try to insert
-            using (var conn = new SqliteConnection(connStr))
-            {
-                conn.Open();
-                using var pragma = conn.CreateCommand();
-                pragma.CommandText = "PRAGMA query_only = ON";
-                pragma.ExecuteNonQuery();
-
-                using var insert = conn.CreateCommand();
-                insert.CommandText = "INSERT INTO Test (Value) VALUES ('should fail')";
-                Assert.ThrowsException<SqliteException>(() => insert.ExecuteNonQuery());
-            }
-        }
-        finally
-        {
-            CleanupDb(dbPath);
-        }
-    }
-
-    [TestMethod]
-    public void QueryOnly_AllowsSelect_AfterEnabled()
-    {
-        var dbPath = $"readonly_test_{Guid.NewGuid():N}.db";
-        try
-        {
-            var connStr = $"Data Source={dbPath};Mode=ReadWriteCreate";
-
-            using (var conn = new SqliteConnection(connStr))
-            {
-                conn.Open();
-                using var cmd = conn.CreateCommand();
-                cmd.CommandText = "CREATE TABLE Test (Id INTEGER PRIMARY KEY, Value TEXT)";
-                cmd.ExecuteNonQuery();
-            }
-
-            // SELECT should succeed with query_only
-            using (var conn = new SqliteConnection(connStr))
-            {
-                conn.Open();
-                using var pragma = conn.CreateCommand();
-                pragma.CommandText = "PRAGMA query_only = ON";
-                pragma.ExecuteNonQuery();
-
-                using var select = conn.CreateCommand();
-                select.CommandText = "SELECT COUNT(*) FROM Test";
-                var result = select.ExecuteScalar();
-                Assert.AreEqual(0L, result);
-            }
-        }
-        finally
-        {
-            CleanupDb(dbPath);
-        }
-    }
-
-    [TestMethod]
-    public void OpenWithPragmas_SetsQueryOnly_WhenDatabaseModeEnabled()
-    {
-        var dbPath = $"readonly_test_{Guid.NewGuid():N}.db";
-        try
-        {
-            var connStr = $"Data Source={dbPath};Mode=ReadWriteCreate";
-
-            // Create table before enabling query_only
-            using (var conn = new SqliteConnection(connStr))
-            {
-                conn.Open();
                 using var cmd = conn.CreateCommand();
                 cmd.CommandText = "CREATE TABLE Test (Id INTEGER PRIMARY KEY)";
                 cmd.ExecuteNonQuery();
             }
 
-            DatabaseMode.EnableQueryOnly();
+            var readOnly = new SqliteDbConnections(dbPath, isReadOnly: true);
+            Assert.ThrowsException<InvalidOperationException>(() => readOnly.OpenWrite());
+        }
+        finally
+        {
+            CleanupDb(dbPath);
+        }
+    }
 
-            // OpenWithPragmas should now set query_only = ON
-            using (var conn = new SqliteConnection(connStr))
+    [TestMethod]
+    public async Task IDbConnections_OpenWriteAsync_ThrowsInvalidOperationException_WhenReadOnly()
+    {
+        var dbPath = $"readonly_test_{Guid.NewGuid():N}.db";
+        try
+        {
+            var writer = new SqliteDbConnections(dbPath, isReadOnly: false);
+            using (var conn = writer.OpenWrite())
             {
-                conn.OpenWithPragmas();
-                using var insert = conn.CreateCommand();
-                insert.CommandText = "INSERT INTO Test (Id) VALUES (1)";
-                Assert.ThrowsException<SqliteException>(() => insert.ExecuteNonQuery());
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = "CREATE TABLE Test (Id INTEGER PRIMARY KEY)";
+                cmd.ExecuteNonQuery();
             }
+
+            var readOnly = new SqliteDbConnections(dbPath, isReadOnly: true);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => readOnly.OpenWriteAsync());
+        }
+        finally
+        {
+            CleanupDb(dbPath);
+        }
+    }
+
+    [TestMethod]
+    public void IDbConnections_OpenRead_Succeeds_WhenReadOnly()
+    {
+        var dbPath = $"readonly_test_{Guid.NewGuid():N}.db";
+        try
+        {
+            var writer = new SqliteDbConnections(dbPath, isReadOnly: false);
+            using (var conn = writer.OpenWrite())
+            {
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = "CREATE TABLE Test (Id INTEGER PRIMARY KEY)";
+                cmd.ExecuteNonQuery();
+            }
+
+            var readOnly = new SqliteDbConnections(dbPath, isReadOnly: true);
+            using var readConn = readOnly.OpenRead();
+            using var selectCmd = readConn.CreateCommand();
+            selectCmd.CommandText = "SELECT COUNT(*) FROM Test";
+            var result = selectCmd.ExecuteScalar();
+            Assert.AreEqual(0L, result);
         }
         finally
         {
@@ -254,18 +216,16 @@ public sealed class ReadOnlyModeTests
         try
         {
             // Create DB with schema using writer mode
-            var writerConnStr = $"Data Source={dbPath};Mode=ReadWriteCreate";
+            var writerConnections = new SqliteDbConnections(dbPath, isReadOnly: false);
             var repo = new SQLiteFeedRepository(
-                writerConnStr,
-                writerConnStr,
+                writerConnections,
                 NullLogger<SQLiteFeedRepository>.Instance,
                 isReadOnly: false);
 
-            // Now open in read-only mode — should NOT throw even without schema init
-            var readerConnStr = $"Data Source={dbPath};Mode=ReadOnly";
+            // Now open in read-only mode  should NOT throw even without schema init
+            var readerConnections = new SqliteDbConnections(dbPath, isReadOnly: true);
             var readOnlyRepo = new SQLiteFeedRepository(
-                writerConnStr,
-                readerConnStr,
+                readerConnections,
                 NullLogger<SQLiteFeedRepository>.Instance,
                 isReadOnly: true);
 
@@ -285,17 +245,15 @@ public sealed class ReadOnlyModeTests
         var dbPath = $"readonly_test_{Guid.NewGuid():N}.db";
         try
         {
-            var writerConnStr = $"Data Source={dbPath};Mode=ReadWriteCreate";
+            var writerConnections = new SqliteDbConnections(dbPath, isReadOnly: false);
             var repo = new SQLiteUserRepository(
-                writerConnStr,
-                writerConnStr,
+                writerConnections,
                 NullLogger<SQLiteUserRepository>.Instance,
                 isReadOnly: false);
 
-            var readerConnStr = $"Data Source={dbPath};Mode=ReadOnly";
+            var readerConnections = new SqliteDbConnections(dbPath, isReadOnly: true);
             var readOnlyRepo = new SQLiteUserRepository(
-                writerConnStr,
-                readerConnStr,
+                readerConnections,
                 NullLogger<SQLiteUserRepository>.Instance,
                 isReadOnly: true);
 

--- a/test/SerializerTests/TagSettingsTests.cs
+++ b/test/SerializerTests/TagSettingsTests.cs
@@ -12,7 +12,6 @@ using RssReader.Server.Services;
 public sealed class TagSettingsTests
 {
     private string testDbFile;
-    private string connectionString;
 
     private SQLiteUserRepository userRepo;
     private SQLiteFeedRepository feedRepo;
@@ -24,15 +23,15 @@ public sealed class TagSettingsTests
     public void Setup()
     {
         testDbFile = $"tagsettings-{Guid.NewGuid():N}.db";
-        connectionString = $"Data Source={testDbFile}";
+        var dbConnections = new SqliteDbConnections(testDbFile, isReadOnly: false);
 
         Directory.CreateDirectory(Path.Combine("wwwroot", "images"));
 
-        userRepo = new SQLiteUserRepository(connectionString, connectionString, new NullLogger<SQLiteUserRepository>());
+        userRepo = new SQLiteUserRepository(dbConnections, new NullLogger<SQLiteUserRepository>());
         userRepo.AddUser("tagTestUser", 0);
         testUser = new RssUser("tagTestUser", 0);
 
-        feedRepo = new SQLiteFeedRepository(connectionString, connectionString, new NullLogger<SQLiteFeedRepository>());
+        feedRepo = new SQLiteFeedRepository(dbConnections, new NullLogger<SQLiteFeedRepository>());
 
         var serviceCollection = new ServiceCollection();
         serviceCollection
@@ -43,8 +42,7 @@ public sealed class TagSettingsTests
             .AddSingleton<IUserRepository>(userRepo)
             .AddSingleton<IItemRepository>(sb =>
                 new SQLiteItemRepository(
-                    connectionString,
-                    connectionString,
+                    dbConnections,
                     sb.GetRequiredService<ILogger<SQLiteItemRepository>>(),
                     sb.GetRequiredService<IFeedRepository>(),
                     sb.GetRequiredService<IUserRepository>(),


### PR DESCRIPTION
## Why

Stacked follow-up on #64. PR #64 ships a working read/write connection-string split, but the abstraction leaks across ~45 call sites and introduces a global mutable static. Pre-merge cleanup pass.

## What changed

- **New `IDbConnections` interface + `SqliteDbConnections` implementation** owns the connection-string + pragma logic. Repos drop their two connection-string fields and call `connections.OpenRead()` / `OpenWrite()` instead.
- **`OpenWrite()` throws `InvalidOperationException` in read-replica mode**  replaces the runtime `query_only` PRAGMA backstop with a structural guarantee. You can't get a write connection in replica mode, so you don't need to enforce read-only on it.
- **`DatabaseMode` static class deleted** (mutable global state, `ResetForTesting` smell).
- **`OpenWithPragmas` / `OpenWithPragmasAsync` thunks deleted**  they parsed the connection string at runtime to pick read vs write. No longer needed; the provider knows.
- **Bug fix**: `RepositoryFactory` now passes `isReadOnly` to **all three** repos (Feed/User were silently missing it).

## Stats

| | |
|---|---|
| Files changed | 14 |
| Net line delta | **135 lines** |
| Build | 0 errors |
| Tests | 111/111 passing |
| `DatabaseMode` references remaining | 0 |
| `OpenWithPragmas` references remaining | 0 |

## Out of scope

- Per-repo `writeSemaphore` (only on `AddItemsAsync`) left as-is. Cross-repo write serialization is a separate concern  `busy_timeout=5000` handles it for now.

## Stacking note

Based on `fix/sqlite-read-write-split` (PR #64). Targets that branch so the diff stays focused on the refactor. Once #64 merges to main, this will rebase cleanly.