### PR TITLE
Show account chooser on Login (prompt=select_account)

### DIFF
--- a/src/WasmApp/Layout/NavMenu.razor
+++ b/src/WasmApp/Layout/NavMenu.razor
@@ -53,7 +53,7 @@
                 <a class="desktop-nav-link" href="/.auth/logout">Logout</a>
             </Authorized>
             <NotAuthorized>
-                <a class="desktop-nav-link" href="/.auth/login/aad">Login</a>
+                <a class="desktop-nav-link" href="/.auth/login/aad?prompt=select_account">Login</a>
             </NotAuthorized>
         </AuthorizeView>
     </div>
@@ -114,7 +114,7 @@
             </Authorized>
             <NotAuthorized>
                 <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="/.auth/login/aad">
+                    <NavLink class="nav-link" href="/.auth/login/aad?prompt=select_account">
                         Login
                     </NavLink>
                 </div>

--- a/src/WasmApp/Pages/Home.razor
+++ b/src/WasmApp/Pages/Home.razor
@@ -44,8 +44,8 @@
 
     private string LoginUrl =>
         string.IsNullOrEmpty(_returnUrl)
-            ? "/.auth/login/aad"
-            : $"/.auth/login/aad?post_login_redirect_uri={_returnUrl}";
+            ? "/.auth/login/aad?prompt=select_account"
+            : $"/.auth/login/aad?post_login_redirect_uri={_returnUrl}&prompt=select_account";
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {


### PR DESCRIPTION
When the user explicitly clicks Login (Home page or NavMenu), append prompt=select_account to the AAD login URL so Entra shows the account picker instead of silently signing them in as the previously-remembered account.

Silent re-auth in AuthenticationHeaderHandler is intentionally unchanged - we still want token refreshes to be silent.