### PR TITLE
Remove redundant SQLite->AzureFiles backup path

### DIFF
--- a/.github/agents/azure-deployer.agent.md
+++ b/.github/agents/azure-deployer.agent.md
@@ -211,8 +211,8 @@ echo $env:GITHUB_PAT | docker login ghcr.io -u $env:GITHUB_USERNAME --password-s
 - Common causes:
   - `RSSREADER_API_KEY` environment variable not set or mismatched with the SWA Function proxy
   - `DbLocation` misconfigured (should be `/tmp/storage.db` inside the container)
-  - Database restore failure on startup (check logs for "RestoreFromBackupAsync" errors)
-  - Azure Files volume mount not available (`/data/storage.db`)
+  - Database restore failure on startup (entrypoint will exit with FATAL if `litestream restore` fails — check container logs for "litestream restore failed")
+  - Image cache restore failure (check logs for "Failed to restore cached images from /data")
 
 ### 5. `swa deploy` auth failure
 ```powershell
@@ -227,10 +227,9 @@ Then retry `swa deploy --env production`.
   (Note: this increases cost — only do if user explicitly requests it.)
 
 ### 7. Database not persisting across restarts
-- The SQLite DB lives at `/tmp/storage.db` (ephemeral) and is backed up to `/data/storage.db` (Azure Files) every 5 minutes.
-- On startup, the app restores from `/data/storage.db` if it exists.
-- If data is lost: check logs for backup/restore errors. The Azure Files share must be mounted at `/data/` in the container.
-- Verify the volume mount in the container app configuration.
+- The SQLite DB lives at `/tmp/storage.db` (ephemeral) and is replicated to Azure Blob Storage by **Litestream** (the sole backup path).
+- On startup, `litestream restore -if-replica-exists` (in `docker-entrypoint.sh`) restores the DB from blob; the entrypoint exits with FATAL if restore fails.
+- If data is lost: check container logs for "litestream restore failed" or `litestream replicate` exit messages; verify the storage account / managed identity grants `Storage Blob Data Contributor` on the `litestream` container.
 
 ### 8. SWA frontend deploys but API calls fail (502 / CORS)
 - The SWA Functions proxy (`api/src/functions/ApiProxy.js`) forwards `/api/*` to the Container App backend.
@@ -260,7 +259,7 @@ Browser → Azure SWA (Easy Auth / AAD)
                           X-Gateway-Key + X-User-Id headers
                         → Azure Container App (rss-reader-api, port 8080)
                               → SQLite at /tmp/storage.db
-                              → Backup to Azure Files at /data/storage.db
+                              → Litestream replicates WAL to Azure Blob Storage
 ```
 
 - The SWA Function proxy injects `X-Gateway-Key` (shared secret) and `X-User-Id` (base64 Easy Auth principal) on every forwarded request.

--- a/.github/agents/full-stack-developer.agent.md
+++ b/.github/agents/full-stack-developer.agent.md
@@ -34,7 +34,7 @@ Browser → Azure SWA (Easy Auth / AAD)
                           X-Gateway-Key + X-User-Id headers
                         → ASP.NET Core backend  (src/Server/)
                               → SQLite at /tmp/storage.db
-                              → Backup to Azure Files at /data/storage.db
+                              → Litestream replicates WAL to Azure Blob Storage
 ```
 
 ### Project layout
@@ -73,8 +73,7 @@ Browser → Azure SWA (Easy Auth / AAD)
 
 ## Tech Stack — Database (SQLite)
 
-- **File location**: `/tmp/storage.db` (ephemeral). Primary replication via Litestream to Azure Blob Storage; secondary backup to `/data/storage.db` (Azure Files) every 5 minutes via `DatabaseBackupService`. Images synced to `/data/images/` on the same cycle.
-- **Backup API**: uses `SqliteConnection.BackupDatabase` (SQLite native backup API) for consistent snapshots — do not replace with file copies
+- **File location**: `/tmp/storage.db` (ephemeral). Replicated to Azure Blob Storage via Litestream — that is the sole DB backup path. `DatabaseBackupService` syncs cached images between `wwwroot/images/` and `/data/images/` every 5 minutes but does NOT touch the DB file.
 - **WAL mode**: the database runs in WAL (Write-Ahead Logging) mode for concurrent reads. Do not change the journal mode
 - **Schema conventions**:
   - Always use `INTEGER PRIMARY KEY` (alias for `rowid`) for surrogate keys

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,11 +85,9 @@ Feed refresh runs via a `BackgroundWorkQueue` + `BackgroundWorker` hosted servic
 App config is loaded into `RssAppConfig` from `appsettings.json` under the `RssAppConfig` section. The backend reads `DbLocation` for the SQLite path (`/tmp/storage.db` in Docker, copied to `/data/` for persistence). Frontend config is in `RssWasmConfig`.
 
 ### DatabaseBackupService
-Complementary backup service that runs alongside Litestream. The SQLite database lives at `/tmp/storage.db` (ephemeral container storage). Litestream handles primary replication to Azure Blob Storage; `DatabaseBackupService` provides a secondary backup to Azure Files (`/data/storage.db`) every 5 minutes and syncs cached images between `wwwroot/images/` and `/data/images/`. On container startup, `Program.cs` explicitly calls `RestoreFromBackupAsync` before any repository is instantiated — this ordering is intentional. If Litestream already restored the database, `DatabaseBackupService` skips DB restore but still restores cached images from Azure Files.
+A periodic image-sync + system-stats service. The SQLite database lives at `/tmp/storage.db` (ephemeral container storage) and is replicated to Azure Blob Storage by **Litestream** (the sole DB backup path). On container startup, `Program.cs` calls `RestoreFromBackupAsync` before any repository is instantiated to copy cached images from `/data/images/` (Azure Files) into `wwwroot/images/`. Every 5 minutes it then syncs new images back from `wwwroot/images/` to `/data/images/` (only new files, never overwrites) and records a system-stats snapshot via a read-only query against the active DB.
 
-The backup cycle uses **SQLite's native backup API** (`SqliteConnection.BackupDatabase`) to create a consistent point-in-time snapshot at `/tmp/storage-backup.db`, then computes a SHA256 hash to skip the Azure Files write if nothing changed (reducing transaction costs). Images in `wwwroot/images/` are also synced to `/data/images/` on the same cycle, but only new files are copied (no overwrites).
-
-On shutdown, `StopAsync` attempts a best-effort final backup with a 5-second timeout. If it fails or times out, the last periodic backup (at most 5 minutes old) provides coverage.
+This service must NEVER write to `/tmp/storage.db` — Litestream owns the DB, and any write here would generate WAL/LTX traffic. The tests assert this contract explicitly.
 
 ### OPML Import/Export
 OPML import/export is handled by the static `OpmlSerializer` class (`src/Server/Services/Serialization/OpmlSerializer.cs`), shared between the backend and tests.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,13 +62,13 @@ The database uses a dual backup strategy:
 
 1. **Litestream** (primary) — Continuously replicates SQLite WAL changes to Azure Blob Storage. On container startup, `docker-entrypoint.sh` runs `litestream restore` to recover the latest state, then starts the app under `litestream replicate` supervision. If Litestream fails (auth error, misconfiguration), the entrypoint falls back to running the app directly. Config: `infrastructure/litestream.yml`.
 
-2. **DatabaseBackupService** (complementary) — Periodically copies the SQLite database to Azure Files every 5 minutes and syncs cached images between `wwwroot/images/` and `/data/images/`. Provides a secondary backup layer alongside Litestream. On startup, if Litestream has already restored the database, `DatabaseBackupService` skips its own DB restore but still restores cached images from Azure Files.
+2. **DatabaseBackupService** (image cache + stats only) — Periodically syncs cached images between `wwwroot/images/` and `/data/images/` every 5 minutes and records system-stats snapshots. Does NOT back up the database — Litestream is the sole DB backup path. On startup, restores cached images from `/data/images/` (Litestream restores the DB before the .NET process starts).
 
 ##### Read Replicas (optional)
 
 The backend supports an optional read replica mode controlled by `RssAppConfig.IsReadOnly` and the `APP_ROLE` environment variable:
 
-- **Writer** (`APP_ROLE=writer`, default) — Single replica, runs Litestream replication, all background services (feed refresh, backup), handles reads and writes.
+- **Writer** (`APP_ROLE=writer`, default) — Single replica, runs Litestream replication, all background services (feed refresh, image sync), handles reads and writes.
 - **Reader** (`APP_ROLE=reader`, `IsReadOnly=true`) — 0→N replicas, restores from Litestream blob on startup, serves read-only traffic. No background services (no feed refresh, no backup). Uses `NoOpFeedRefresher` so controllers still resolve.
 
 The Azure Functions proxy (`api/src/functions/ApiProxy.js`) routes GET requests for read-heavy endpoints (timeline, feed list, search, content) to the reader when `RSSREADER_READER_API_URL` is configured. All write endpoints and the `user` endpoint always go to the writer. If the reader is unavailable (5xx or network error), the proxy falls back to the writer.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -140,16 +140,12 @@ az containerapp logs show --name rss-reader-api --resource-group rss-container-r
 ```
 
 ### Verify storage mount
-The SQLite database should persist at `/data/storage.db` inside the container, mounted from Azure Files.
+The Azure Files mount at `/data/` persists cached feed images at `/data/images/`. The SQLite database is **not** backed up to Azure Files — it lives at `/tmp/storage.db` and is replicated to Azure Blob Storage by Litestream.
 
-### Litestream Migration Notes
-The Docker image includes [Litestream](https://litestream.io/) for continuous SQLite replication to Azure Blob Storage. `DatabaseBackupService` runs alongside Litestream, providing a secondary backup to Azure Files and syncing cached images. The entrypoint includes a graceful fallback — if Litestream fails to start (auth error, misconfiguration), the app runs directly with `DatabaseBackupService` providing backup coverage. On first deployment:
+### Litestream Notes
+The Docker image includes [Litestream](https://litestream.io/) for continuous SQLite replication to Azure Blob Storage. **Litestream is the sole DB backup path**: the entrypoint runs `litestream restore -if-replica-exists` before starting the app and exits with a fatal error if restore fails (to avoid orphaning the replica with a fresh empty-DB generation). The app then runs under `litestream replicate` supervision, which streams WAL changes to the `litestream` blob container. `DatabaseBackupService` runs alongside but only handles image cache sync and system-stats snapshots — it does not touch the DB file.
 
-1. **Litestream restore is a no-op** — the blob container is empty, so the entrypoint script's `litestream restore -if-replica-exists` succeeds silently.
-2. **DatabaseBackupService restores from Azure Files** — the existing backup at `/data/storage.db` is copied to `/tmp/storage.db` as before.
-3. **Litestream starts replicating** — WAL changes are continuously streamed to the `litestream` blob container.
-
-On subsequent boots, Litestream restores from blob (more up-to-date than Azure Files). `DatabaseBackupService` skips its own DB restore (active DB already exists) but still restores cached images from Azure Files. Both services then run in parallel — Litestream for continuous WAL replication, `DatabaseBackupService` for periodic Azure Files backup and image sync.
+On first deployment the blob container is empty, so `litestream restore -if-replica-exists` succeeds silently and the app starts with a brand-new DB; `litestream replicate` then begins seeding the blob.
 
 **Required environment variables** (set via Bicep):
 - `LITESTREAM_AZURE_ACCOUNT_NAME` — storage account name

--- a/infrastructure/docker-entrypoint.sh
+++ b/infrastructure/docker-entrypoint.sh
@@ -32,15 +32,24 @@ fi
 
 # Writer mode: restore from Litestream if a replica exists, then start
 # under Litestream's process supervision for continuous WAL replication.
-litestream restore -if-replica-exists -config /etc/litestream.yml /tmp/storage.db || \
-    echo "WARNING: Litestream restore failed. DatabaseBackupService will restore from Azure Files." >&2
+#
+# Litestream is now the SOLE backup path for the SQLite database — the previous
+# secondary AzureFiles backup (DatabaseBackupService -> /data/storage.db) was
+# removed. If `litestream restore` fails here, we MUST fail fast: starting the
+# app on an empty DB would cause `litestream replicate` to mint a fresh
+# generation against the empty file and orphan the existing replica
+# (silent data loss).
+if ! litestream restore -if-replica-exists -config /etc/litestream.yml /tmp/storage.db; then
+    echo "FATAL: litestream restore failed. Refusing to start with empty DB to avoid orphaning the replica." >&2
+    echo "       Investigate Litestream auth / blob connectivity before restarting." >&2
+    exit 1
+fi
 
 # Litestream continuously replicates WAL changes to Blob Storage.
-# If Litestream fails (auth error, misconfiguration), fall back to running
-# the app directly so DatabaseBackupService can still provide backup coverage.
 litestream replicate -exec "dotnet Server.dll" -config /etc/litestream.yml
 exit_code=$?
 
-# If we reach here, Litestream exited. Fall back to running without replication.
-echo "WARNING: Litestream replicate exited ($exit_code). Starting app without replication." >&2
-exec dotnet Server.dll
+# If `litestream replicate` itself exits, surface the error rather than running
+# unreplicated — the app would write to /tmp/storage.db with no backup at all.
+echo "FATAL: litestream replicate exited ($exit_code). Container will exit so it can be restarted with replication." >&2
+exit $exit_code

--- a/infrastructure/litestream.yml
+++ b/infrastructure/litestream.yml
@@ -13,3 +13,8 @@ dbs:
         # Batch WAL frame uploads to reduce blob storage transaction costs.
         # Trade-off: up to 30s RPO if the container dies between syncs.
         sync-interval: 30s
+        # Take a full snapshot every hour. Default is 24h, which lets the LTX
+        # chain accumulate ~24h of writes — observed to grow to ~1GB on cold
+        # start, slowing container boot. Hourly snapshots cap the chain at
+        # ~1h of writes at the cost of one extra full-DB upload per hour.
+        snapshot-interval: 1h

--- a/src/Server/Services/DatabaseBackupService.cs
+++ b/src/Server/Services/DatabaseBackupService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
@@ -14,28 +13,34 @@ using RssApp.Data;
 namespace RssReader.Server.Services
 {
     /// <summary>
-    /// Configuration for database backup file paths. Extracted for testability.
+    /// Configuration for image and stats paths. Extracted for testability.
     /// </summary>
+    /// <remarks>
+    /// As of the Litestream migration, the SQLite database itself is no longer backed up by this
+    /// service — Litestream replicates the DB to Azure Blob Storage. This record only retains the
+    /// active DB path (used for stats snapshots) and image sync paths.
+    /// </remarks>
     public record DatabaseBackupPaths(
         string ActiveDbPath = "/tmp/storage.db",
-        string BackupDbPath = "/data/storage.db",
-        string TempBackupDbPath = "/tmp/storage-backup.db",
         string ActiveImagesPath = "wwwroot/images/",
         string BackupImagesPath = "/data/images/");
 
     /// <summary>
-    /// Complementary backup service that runs alongside Litestream.
-    /// - On startup: Restores database from Azure Files backup if Litestream hasn't already restored it; always restores cached images.
-    /// - Periodically: Backs up active database to Azure Files and syncs cached images to/from mounted storage.
-    /// Litestream handles primary WAL replication to Azure Blob Storage; this service provides a secondary backup layer and image persistence.
+    /// Periodically syncs cached images between the ephemeral container filesystem (wwwroot/images)
+    /// and the persistent Azure Files mount (/data/images), and records system stats snapshots.
+    ///
+    /// Note: this service used to also back up the SQLite database to Azure Files via SQLite's
+    /// BackupDatabase() API. That responsibility now belongs entirely to Litestream, which
+    /// replicates the WAL to Azure Blob Storage. The previous implementation triggered WAL
+    /// checkpoints on every backup cycle, causing Litestream to capture full-DB-sized LTX deltas
+    /// (~127 MB every 5 min) and bloat the cold-start restore chain.
     /// </summary>
     public class DatabaseBackupService : BackgroundService
     {
         private readonly ILogger<DatabaseBackupService> _logger;
         private readonly DatabaseBackupPaths _paths;
         private readonly IServiceProvider _serviceProvider;
-        private readonly TimeSpan _backupInterval = TimeSpan.FromMinutes(5);
-        private string _lastBackupHash = string.Empty;
+        private readonly TimeSpan _syncInterval = TimeSpan.FromMinutes(5);
 
         public DatabaseBackupService(ILogger<DatabaseBackupService> logger)
             : this(logger, new DatabaseBackupPaths(), null)
@@ -59,71 +64,41 @@ namespace RssReader.Server.Services
 
         public override async Task StartAsync(CancellationToken cancellationToken)
         {
-            _logger.LogInformation("DatabaseBackupService starting...");
-            
-            // Restore from backup on startup
+            _logger.LogInformation("DatabaseBackupService starting (image sync + stats only)...");
+
+            // Restore cached images from the persistent /data mount on startup.
             await RestoreFromBackupAsync(cancellationToken);
-            
+
             await base.StartAsync(cancellationToken);
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            _logger.LogInformation("DatabaseBackupService is running. Backup interval: {Interval} minutes", _backupInterval.TotalMinutes);
+            _logger.LogInformation("DatabaseBackupService is running. Sync interval: {Interval} minutes", _syncInterval.TotalMinutes);
 
             while (!stoppingToken.IsCancellationRequested)
             {
                 try
                 {
-                    await Task.Delay(_backupInterval, stoppingToken);
-                    
+                    await Task.Delay(_syncInterval, stoppingToken);
+
                     if (!stoppingToken.IsCancellationRequested)
                     {
-                        await BackupToStorageAsync(stoppingToken);
+                        await SyncImagesAsync(stoppingToken);
                         await RecordStatsSnapshotAsync();
                     }
                 }
                 catch (OperationCanceledException)
                 {
-                    // Expected when shutting down
                     _logger.LogInformation("DatabaseBackupService is shutting down");
                     break;
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error during database backup cycle");
+                    _logger.LogError(ex, "Error during periodic sync cycle");
                     // Continue running despite errors
                 }
             }
-        }
-
-        public override async Task StopAsync(CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("DatabaseBackupService stopping. Attempting best-effort final backup...");
-            
-            try
-            {
-                // Give other background services (BackgroundWorker, FeedRefresher) a moment to 
-                // finish their current database operations before we attempt backup
-                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
-                
-                // Use a short timeout for the final backup to avoid delaying container shutdown
-                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                timeoutCts.CancelAfter(TimeSpan.FromSeconds(5));
-                
-                await BackupToStorageAsync(timeoutCts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogWarning("Final backup cancelled or timed out during shutdown. Last periodic backup is current (max 5 min old)");
-            }
-            catch (Exception ex)
-            {
-                // Don't treat shutdown backup failures as errors - periodic backups provide coverage
-                _logger.LogWarning(ex, "Final backup skipped due to shutdown timing. Last periodic backup is current (max 5 min old)");
-            }
-            
-            await base.StopAsync(cancellationToken);
         }
 
         private async Task RecordStatsSnapshotAsync()
@@ -188,221 +163,76 @@ namespace RssReader.Server.Services
             }
         }
 
+        /// <summary>
+        /// Restores cached images from the persistent /data mount on startup. The DB itself is
+        /// restored by Litestream (run before the .NET process starts in docker-entrypoint.sh).
+        /// </summary>
         public async Task RestoreFromBackupAsync(CancellationToken cancellationToken)
         {
             try
             {
-                // Check if backup exists
-                if (!File.Exists(_paths.BackupDbPath))
-                {
-                    _logger.LogInformation("No backup database found at {BackupPath}. Starting with empty database", _paths.BackupDbPath);
-                    return;
-                }
-
-                // Check if active database already exists (Litestream may have restored it)
-                if (File.Exists(_paths.ActiveDbPath))
-                {
-                    _logger.LogWarning("Active database already exists at {ActivePath}. Skipping DB restore", _paths.ActiveDbPath);
-                }
-                else
-                {
-                    // Ensure /tmp directory exists
-                    var activeDir = Path.GetDirectoryName(_paths.ActiveDbPath);
-                    if (!string.IsNullOrEmpty(activeDir) && !Directory.Exists(activeDir))
-                    {
-                        Directory.CreateDirectory(activeDir);
-                    }
-
-                    _logger.LogInformation("Restoring database from {BackupPath} to {ActivePath}", _paths.BackupDbPath, _paths.ActiveDbPath);
-                    
-                    // Simple file copy on startup is safe since nothing is using the database yet
-                    await CopyFileAsync(_paths.BackupDbPath, _paths.ActiveDbPath, cancellationToken);
-                    
-                    // Compute hash of the backup so we can detect changes later
-                    _lastBackupHash = await ComputeFileHashAsync(_paths.BackupDbPath, cancellationToken);
-                    _logger.LogInformation("Computed baseline backup hash for change detection");
-                    
-                    var fileInfo = new FileInfo(_paths.ActiveDbPath);
-                    _logger.LogInformation("Database restored successfully. Size: {Size:N0} bytes", fileInfo.Length);
-                }
-
-                // Always restore images, even if DB was already restored by Litestream
                 await CopyFilesAsync(_paths.BackupImagesPath, _paths.ActiveImagesPath, cancellationToken);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to restore database from backup. Starting with empty database");
+                _logger.LogError(ex, "Failed to restore cached images from /data");
             }
         }
 
-        internal async Task BackupToStorageAsync(CancellationToken cancellationToken)
+        /// <summary>
+        /// Syncs new images from wwwroot/images to /data/images so they survive container recycles.
+        /// </summary>
+        internal async Task SyncImagesAsync(CancellationToken cancellationToken)
         {
             try
             {
-                // Check if active database exists
-                if (!File.Exists(_paths.ActiveDbPath))
-                {
-                    _logger.LogWarning("No active database found at {ActivePath}. Skipping backup", _paths.ActiveDbPath);
-                    return;
-                }
-
-                // Ensure backup directory exists
-                var backupDir = Path.GetDirectoryName(_paths.BackupDbPath);
-                if (!string.IsNullOrEmpty(backupDir) && !Directory.Exists(backupDir))
-                {
-                    Directory.CreateDirectory(backupDir);
-                    _logger.LogInformation("Created backup directory: {BackupDir}", backupDir);
-                }
-
-                _logger.LogInformation("Backing up database from {ActivePath} to {BackupPath}", _paths.ActiveDbPath, _paths.BackupDbPath);
-                
-                // Create backup in /tmp first (SQLite backup API doesn't work well with network filesystems)
-                var tempBackupPath = _paths.TempBackupDbPath;
-                
-                // Delete any existing temp backup file
-                if (File.Exists(tempBackupPath))
-                {
-                    File.Delete(tempBackupPath);
-                }
-                
-                try
-                {
-                    // Use SQLite's native backup API to create consistent backup in /tmp
-                    await PerformSqliteBackupAsync(_paths.ActiveDbPath, tempBackupPath, cancellationToken);
-                    
-                    // Compute hash of the backup to detect changes
-                    var backupHash = await ComputeFileHashAsync(tempBackupPath, cancellationToken);
-                    
-                    // Only copy to Azure Files if content has changed
-                    if (backupHash != _lastBackupHash)
-                    {
-                        _logger.LogInformation("Database content changed. Uploading to Azure Files...");
-                        await CopyFileAsync(tempBackupPath, _paths.BackupDbPath, cancellationToken);
-                        _lastBackupHash = backupHash;
-                        
-                        var fileInfo = new FileInfo(_paths.BackupDbPath);
-                        _logger.LogInformation("Database backed up successfully. Size: {Size:N0} bytes", fileInfo.Length);
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Database content unchanged. Skipping upload to Azure Files (saving transaction costs)");
-                    }
-                    
-                    // Backup image files
-                    await CopyFilesAsync(_paths.ActiveImagesPath, _paths.BackupImagesPath, cancellationToken);
-                }
-                finally
-                {
-                    // Always clean up temp backup file, even if an error occurred
-                    if (File.Exists(tempBackupPath))
-                    {
-                        File.Delete(tempBackupPath);
-                    }
-                }
+                await CopyFilesAsync(_paths.ActiveImagesPath, _paths.BackupImagesPath, cancellationToken);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to backup database to storage");
+                _logger.LogError(ex, "Failed to sync cached images to /data");
             }
-        }
-
-        /// <summary>
-        /// Computes SHA256 hash of a file to detect content changes
-        /// </summary>
-        private async Task<string> ComputeFileHashAsync(string filePath, CancellationToken cancellationToken)
-        {
-            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            var hashBytes = await SHA256.HashDataAsync(stream, cancellationToken);
-            return Convert.ToHexString(hashBytes);
-        }
-
-        /// <summary>
-        /// Uses SQLite's native backup API to create a consistent backup while the database is in use.
-        /// This is much safer than copying files directly and prevents database corruption.
-        /// </summary>
-        private async Task PerformSqliteBackupAsync(string sourceDbPath, string destDbPath, CancellationToken cancellationToken)
-        {
-            await Task.Run(() =>
-            {
-                using var source = new SqliteConnection($"Data Source={sourceDbPath};Mode=ReadOnly;Pooling=False");
-                using var destination = new SqliteConnection($"Data Source={destDbPath};Mode=ReadWriteCreate;Pooling=False");
-                
-                source.Open();
-                destination.Open();
-                
-                // SQLite's backup API creates a consistent point-in-time snapshot
-                // even while other connections are reading/writing
-                source.BackupDatabase(destination);
-                
-            }, cancellationToken);
-        }
-
-        private async Task CopyFileAsync(string sourcePath, string destPath, CancellationToken cancellationToken)
-        {
-            // Use buffered copy for better performance
-            using var sourceStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var destStream = new FileStream(destPath, FileMode.Create, FileAccess.Write, FileShare.None);
-            
-            await sourceStream.CopyToAsync(destStream, 81920, cancellationToken); // 80KB buffer
-            await destStream.FlushAsync(cancellationToken);
         }
 
         private async Task CopyFilesAsync(string sourceDir, string destDir, CancellationToken cancellationToken)
         {
             try
             {
-                // Check if source directory exists
                 if (!Directory.Exists(sourceDir))
                 {
                     _logger.LogInformation("Source directory {SourceDir} does not exist. Skipping copy.", sourceDir);
                     return;
                 }
 
-                // Ensure destination directory exists
                 if (!Directory.Exists(destDir))
                 {
                     Directory.CreateDirectory(destDir);
-                    _logger.LogInformation("Created destination directory: {DestDir}", destDir);
                 }
 
-                // Get all files in source directory
-                var sourceFiles = Directory.GetFiles(sourceDir);
-                
-                if (sourceFiles.Length == 0)
+                var files = Directory.GetFiles(sourceDir);
+                int copied = 0;
+                foreach (var sourceFile in files)
                 {
-                    _logger.LogInformation("No files found in {SourceDir}", sourceDir);
-                    return;
-                }
+                    if (cancellationToken.IsCancellationRequested) break;
 
-                // Get existing files in destination to avoid re-copying static files
-                var existingDestFiles = new HashSet<string>(
-                    Directory.GetFiles(destDir).Select(Path.GetFileName),
-                    StringComparer.OrdinalIgnoreCase
-                );
-
-                var filesToCopy = sourceFiles
-                    .Where(f => !existingDestFiles.Contains(Path.GetFileName(f)))
-                    .ToList();
-
-                if (filesToCopy.Count == 0)
-                {
-                    _logger.LogInformation("All {FileCount} files already backed up in {DestDir}. Skipping (saving transaction costs)", sourceFiles.Length, destDir);
-                    return;
-                }
-
-                _logger.LogInformation("Copying {NewCount} new files from {SourceDir} to {DestDir} ({SkippedCount} already backed up)", 
-                    filesToCopy.Count, sourceDir, destDir, sourceFiles.Length - filesToCopy.Count);
-
-                // Copy only new files
-                foreach (var sourceFile in filesToCopy)
-                {
                     var fileName = Path.GetFileName(sourceFile);
                     var destFile = Path.Combine(destDir, fileName);
-                    
-                    await CopyFileAsync(sourceFile, destFile, cancellationToken);
+
+                    // Only copy new files (no overwrites)
+                    if (!File.Exists(destFile))
+                    {
+                        using var sourceStream = new FileStream(sourceFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+                        using var destStream = new FileStream(destFile, FileMode.Create, FileAccess.Write, FileShare.None);
+                        await sourceStream.CopyToAsync(destStream, 81920, cancellationToken);
+                        await destStream.FlushAsync(cancellationToken);
+                        copied++;
+                    }
                 }
 
-                _logger.LogInformation("Successfully copied {FileCount} new files", filesToCopy.Count);
+                if (copied > 0)
+                {
+                    _logger.LogInformation("Copied {Count} new file(s) from {SourceDir} to {DestDir}", copied, sourceDir, destDir);
+                }
             }
             catch (Exception ex)
             {

--- a/test/SerializerTests/DatabaseBackupServiceTests.cs
+++ b/test/SerializerTests/DatabaseBackupServiceTests.cs
@@ -10,8 +10,6 @@ public class DatabaseBackupServiceTests
 {
     private string _testDir = null!;
     private string _activeDbPath = null!;
-    private string _backupDbPath = null!;
-    private string _tempBackupDbPath = null!;
     private string _activeImagesPath = null!;
     private string _backupImagesPath = null!;
     private DatabaseBackupPaths _paths = null!;
@@ -24,18 +22,13 @@ public class DatabaseBackupServiceTests
         Directory.CreateDirectory(_testDir);
 
         _activeDbPath = Path.Combine(_testDir, "active", "storage.db");
-        _backupDbPath = Path.Combine(_testDir, "backup", "storage.db");
-        _tempBackupDbPath = Path.Combine(_testDir, "active", "storage-backup.db");
         _activeImagesPath = Path.Combine(_testDir, "active", "images");
         _backupImagesPath = Path.Combine(_testDir, "backup", "images");
 
         Directory.CreateDirectory(Path.GetDirectoryName(_activeDbPath)!);
-        Directory.CreateDirectory(Path.GetDirectoryName(_backupDbPath)!);
 
         _paths = new DatabaseBackupPaths(
             ActiveDbPath: _activeDbPath,
-            BackupDbPath: _backupDbPath,
-            TempBackupDbPath: _tempBackupDbPath,
             ActiveImagesPath: _activeImagesPath,
             BackupImagesPath: _backupImagesPath);
 
@@ -47,11 +40,7 @@ public class DatabaseBackupServiceTests
     [TestCleanup]
     public void Cleanup()
     {
-        // SQLite connection pooling keeps file handles open on Windows.
-        // Must clear all pools before deleting temp files.
         SqliteConnection.ClearAllPools();
-
-        // Brief delay to let OS release file handles
         Thread.Sleep(50);
 
         try
@@ -65,58 +54,12 @@ public class DatabaseBackupServiceTests
         }
     }
 
-    // ── Restore Tests ─────────────────────────────────────────────────
+    // ── Image Restore Tests ───────────────────────────────────────────
 
     [TestMethod]
-    public async Task Restore_WhenActiveDbAlreadyExists_SkipsRestore()
+    public async Task Restore_WhenBackupImagesExist_CopiesImagesToActiveDir()
     {
-        // Arrange: Litestream already restored the DB (active exists)
-        // Backup has DIFFERENT content — if restore runs, it would overwrite
-        CreateSqliteDb(_activeDbPath, "active_data");
-        CreateSqliteDb(_backupDbPath, "stale_backup_data");
-
-        // Act
-        await _service.RestoreFromBackupAsync(CancellationToken.None);
-
-        // Assert: active DB is untouched (still has original content)
-        var content = ReadSqliteData(_activeDbPath);
-        Assert.AreEqual("active_data", content,
-            "Active DB must NOT be overwritten when it already exists (Litestream coexistence contract)");
-    }
-
-    [TestMethod]
-    public async Task Restore_WhenBackupExistsAndActiveDoesNot_CopiesBackup()
-    {
-        // Arrange: first boot, Litestream had nothing, DatabaseBackupService restores from Azure Files
-        CreateSqliteDb(_backupDbPath, "backup_data");
-
-        // Act
-        await _service.RestoreFromBackupAsync(CancellationToken.None);
-
-        // Assert
-        Assert.IsTrue(File.Exists(_activeDbPath), "Active DB should be created from backup");
-        var content = ReadSqliteData(_activeDbPath);
-        Assert.AreEqual("backup_data", content);
-    }
-
-    [TestMethod]
-    public async Task Restore_WhenNoBackupExists_DoesNothing()
-    {
-        // Arrange: brand new container, no data anywhere
-        // Neither active nor backup DB exists
-
-        // Act
-        await _service.RestoreFromBackupAsync(CancellationToken.None);
-
-        // Assert
-        Assert.IsFalse(File.Exists(_activeDbPath), "No DB should be created when no backup exists");
-    }
-
-    [TestMethod]
-    public async Task Restore_WhenBackupExistsAndImagesExist_CopiesImages()
-    {
-        // Arrange
-        CreateSqliteDb(_backupDbPath, "data");
+        // Arrange: images exist in /data/images
         Directory.CreateDirectory(_backupImagesPath);
         await File.WriteAllTextAsync(Path.Combine(_backupImagesPath, "logo.png"), "image_bytes");
 
@@ -124,181 +67,100 @@ public class DatabaseBackupServiceTests
         await _service.RestoreFromBackupAsync(CancellationToken.None);
 
         // Assert
-        Assert.IsTrue(File.Exists(Path.Combine(_activeImagesPath, "logo.png")));
+        Assert.IsTrue(File.Exists(Path.Combine(_activeImagesPath, "logo.png")),
+            "Cached images should be restored from /data on startup");
     }
 
     [TestMethod]
-    public async Task Restore_WhenBackupDbIsCorrupt_HandlesGracefully()
+    public async Task Restore_WhenNoBackupImagesDir_DoesNotThrow()
     {
-        // Arrange: backup file exists but isn't a valid SQLite DB
-        // RestoreFromBackupAsync does a raw file copy — it should still succeed
-        await File.WriteAllTextAsync(_backupDbPath, "not_a_real_database");
+        // Arrange: no backup images dir at all (fresh container, fresh /data mount)
+
+        // Act + Assert: should not throw
+        await _service.RestoreFromBackupAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task Restore_DoesNotTouchActiveDatabase()
+    {
+        // Arrange: active DB exists (Litestream restored it). Restore must not modify it.
+        CreateSqliteDb(_activeDbPath, "litestream_data");
+        var beforeWriteTime = File.GetLastWriteTimeUtc(_activeDbPath);
+        await Task.Delay(50);
 
         // Act
         await _service.RestoreFromBackupAsync(CancellationToken.None);
 
-        // Assert: file is copied as-is (raw copy, no validation)
-        Assert.IsTrue(File.Exists(_activeDbPath));
-        var content = await File.ReadAllTextAsync(_activeDbPath);
-        Assert.AreEqual("not_a_real_database", content);
+        // Assert: DB file unchanged (Litestream owns the DB; this service only handles images)
+        var afterWriteTime = File.GetLastWriteTimeUtc(_activeDbPath);
+        Assert.AreEqual(beforeWriteTime, afterWriteTime,
+            "RestoreFromBackupAsync must never touch the active DB — Litestream owns DB restore");
+        var content = ReadSqliteData(_activeDbPath);
+        Assert.AreEqual("litestream_data", content);
     }
 
-    // ── Backup Tests ──────────────────────────────────────────────────
+    // ── Image Sync Tests ──────────────────────────────────────────────
 
     [TestMethod]
-    public async Task Backup_WhenNoActiveDb_SkipsBackup()
+    public async Task SyncImages_CopiesNewActiveImagesToBackup()
     {
-        // Arrange: no active DB
+        // Arrange: a freshly cached image in wwwroot/images that hasn't been synced yet
+        Directory.CreateDirectory(_activeImagesPath);
+        await File.WriteAllTextAsync(Path.Combine(_activeImagesPath, "feed-icon.png"), "bytes");
 
         // Act
-        await _service.BackupToStorageAsync(CancellationToken.None);
-
-        // Assert: no backup created
-        Assert.IsFalse(File.Exists(_backupDbPath), "No backup should be created when no active DB exists");
-    }
-
-    [TestMethod]
-    public async Task Backup_WhenActiveDbExists_CreatesBackup()
-    {
-        // Arrange
-        CreateSqliteDb(_activeDbPath, "live_data");
-
-        // Act
-        await _service.BackupToStorageAsync(CancellationToken.None);
+        await _service.SyncImagesAsync(CancellationToken.None);
 
         // Assert
-        Assert.IsTrue(File.Exists(_backupDbPath), "Backup should be created from active DB");
+        Assert.IsTrue(File.Exists(Path.Combine(_backupImagesPath, "feed-icon.png")),
+            "New images should be copied to /data on the periodic sync cycle");
     }
 
     [TestMethod]
-    public async Task Backup_WhenCalledTwiceWithNoChanges_SkipsSecondWrite()
+    public async Task SyncImages_DoesNotOverwriteExistingBackupFile()
     {
-        // Arrange
-        CreateSqliteDb(_activeDbPath, "stable_data");
-
-        // Act — first backup
-        await _service.BackupToStorageAsync(CancellationToken.None);
-        Assert.IsTrue(File.Exists(_backupDbPath));
-        var firstWriteTime = File.GetLastWriteTimeUtc(_backupDbPath);
-
-        // Small delay to ensure timestamp would differ
-        await Task.Delay(100);
-
-        // Second backup (same data)
-        await _service.BackupToStorageAsync(CancellationToken.None);
-
-        // Assert: backup file was NOT re-written (hash match optimization)
-        var secondWriteTime = File.GetLastWriteTimeUtc(_backupDbPath);
-        Assert.AreEqual(firstWriteTime, secondWriteTime,
-            "Backup should be skipped when DB hash is unchanged (cost optimization)");
-    }
-
-    [TestMethod]
-    public async Task Backup_WhenDataChanges_WritesNewBackup()
-    {
-        // Arrange
-        CreateSqliteDb(_activeDbPath, "original_data");
-
-        // First backup
-        await _service.BackupToStorageAsync(CancellationToken.None);
-        Assert.IsTrue(File.Exists(_backupDbPath));
-        var firstWriteTime = File.GetLastWriteTimeUtc(_backupDbPath);
-        await Task.Delay(100);
-
-        // Change the active DB
-        InsertSqliteData(_activeDbPath, "new_data");
-
-        // Second backup
-        await _service.BackupToStorageAsync(CancellationToken.None);
-
-        // Assert: backup was updated
-        var secondWriteTime = File.GetLastWriteTimeUtc(_backupDbPath);
-        Assert.AreNotEqual(firstWriteTime, secondWriteTime,
-            "Backup should be updated when DB content changes");
-    }
-
-    [TestMethod]
-    public async Task Backup_CleansUpTempFile()
-    {
-        // Arrange
-        CreateSqliteDb(_activeDbPath, "data");
-
-        // Act
-        await _service.BackupToStorageAsync(CancellationToken.None);
-
-        // Assert: temp backup file is cleaned up
-        Assert.IsFalse(File.Exists(_tempBackupDbPath),
-            "Temp backup file should be cleaned up after backup completes");
-    }
-
-    [TestMethod]
-    public async Task Restore_WhenActiveDbExistsAndImagesExist_StillRestoresImages()
-    {
-        // Arrange: Litestream restored the DB, but images are only in Azure Files backup
-        CreateSqliteDb(_activeDbPath, "litestream_data");
-        CreateSqliteDb(_backupDbPath, "backup_data");
+        // Arrange: file with the same name already exists in backup with different content
+        Directory.CreateDirectory(_activeImagesPath);
         Directory.CreateDirectory(_backupImagesPath);
-        await File.WriteAllTextAsync(Path.Combine(_backupImagesPath, "feed-icon.png"), "image_bytes");
+        await File.WriteAllTextAsync(Path.Combine(_activeImagesPath, "shared.png"), "active_version");
+        await File.WriteAllTextAsync(Path.Combine(_backupImagesPath, "shared.png"), "backup_version");
 
         // Act
-        await _service.RestoreFromBackupAsync(CancellationToken.None);
+        await _service.SyncImagesAsync(CancellationToken.None);
 
-        // Assert: DB is untouched (Litestream's data preserved)
-        var content = ReadSqliteData(_activeDbPath);
-        Assert.AreEqual("litestream_data", content,
-            "Active DB must not be overwritten");
-
-        // Assert: images ARE restored even though DB restore was skipped
-        Assert.IsTrue(File.Exists(Path.Combine(_activeImagesPath, "feed-icon.png")),
-            "Images must be restored even when DB restore is skipped (Litestream coexistence)");
-    }
-
-    // ── Full Lifecycle Tests (Litestream coexistence) ─────────────────
-
-    [TestMethod]
-    public async Task Lifecycle_LitestreamRestoredFirst_BackupServiceSkipsThenBacksUp()
-    {
-        // Simulates the Litestream coexistence scenario:
-        // 1. Litestream restores DB before app starts (active DB exists)
-        // 2. DatabaseBackupService.Restore skips (doesn't overwrite)
-        // 3. DatabaseBackupService.Backup still runs (writes to Azure Files)
-
-        // Step 1: Simulate Litestream restore
-        CreateSqliteDb(_activeDbPath, "litestream_restored_data");
-
-        // Step 2: DatabaseBackupService restore — should skip
-        await _service.RestoreFromBackupAsync(CancellationToken.None);
-        var contentAfterRestore = ReadSqliteData(_activeDbPath);
-        Assert.AreEqual("litestream_restored_data", contentAfterRestore,
-            "Restore must not overwrite Litestream's data");
-
-        // Step 3: DatabaseBackupService backup — should still work
-        await _service.BackupToStorageAsync(CancellationToken.None);
-        Assert.IsTrue(File.Exists(_backupDbPath),
-            "Backup should still run even when restore was skipped");
+        // Assert: backup file is preserved (sync skips files that already exist in destination)
+        var content = await File.ReadAllTextAsync(Path.Combine(_backupImagesPath, "shared.png"));
+        Assert.AreEqual("backup_version", content,
+            "Sync must NOT overwrite existing backup files");
     }
 
     [TestMethod]
-    public async Task Lifecycle_FirstBoot_RestoresFromBackupThenBacksUp()
+    public async Task SyncImages_WhenNoActiveImages_DoesNothing()
     {
-        // Simulates first boot after Litestream is added:
-        // 1. Litestream restore is no-op (nothing in blob yet)
-        // 2. DatabaseBackupService restores from Azure Files
-        // 3. Subsequent backup works
+        // Arrange: no wwwroot/images directory
 
-        // Step 1: Litestream no-op (we don't create active DB)
-        CreateSqliteDb(_backupDbPath, "azure_files_data");
+        // Act + Assert: should not throw, should not create backup directory
+        await _service.SyncImagesAsync(CancellationToken.None);
+    }
 
-        // Step 2: DatabaseBackupService restores
-        await _service.RestoreFromBackupAsync(CancellationToken.None);
-        Assert.IsTrue(File.Exists(_activeDbPath));
-        var content = ReadSqliteData(_activeDbPath);
-        Assert.AreEqual("azure_files_data", content);
+    [TestMethod]
+    public async Task SyncImages_DoesNotTouchActiveDatabase()
+    {
+        // Arrange: active DB exists. The image sync must never write to /tmp/storage.db
+        // because that would trigger Litestream LTX deltas.
+        CreateSqliteDb(_activeDbPath, "live_data");
+        Directory.CreateDirectory(_activeImagesPath);
+        await File.WriteAllTextAsync(Path.Combine(_activeImagesPath, "icon.png"), "bytes");
+        var beforeWriteTime = File.GetLastWriteTimeUtc(_activeDbPath);
+        await Task.Delay(50);
 
-        // Step 3: Mutate and backup
-        InsertSqliteData(_activeDbPath, "new_entry");
-        await _service.BackupToStorageAsync(CancellationToken.None);
-        Assert.IsTrue(File.Exists(_backupDbPath));
+        // Act
+        await _service.SyncImagesAsync(CancellationToken.None);
+
+        // Assert: the DB file's mtime is unchanged
+        var afterWriteTime = File.GetLastWriteTimeUtc(_activeDbPath);
+        Assert.AreEqual(beforeWriteTime, afterWriteTime,
+            "Image sync must NEVER write to the active DB (Litestream replication contract)");
     }
 
     // ── Helpers ────────────────────────────────────────────────────────
@@ -314,16 +176,6 @@ public class DatabaseBackupServiceTests
         using var cmd = conn.CreateCommand();
         cmd.CommandText = "CREATE TABLE IF NOT EXISTS test_data (value TEXT); INSERT INTO test_data VALUES ($v);";
         cmd.Parameters.AddWithValue("$v", seedValue);
-        cmd.ExecuteNonQuery();
-    }
-
-    private static void InsertSqliteData(string path, string value)
-    {
-        using var conn = new SqliteConnection($"Data Source={path}");
-        conn.Open();
-        using var cmd = conn.CreateCommand();
-        cmd.CommandText = "INSERT INTO test_data VALUES ($v);";
-        cmd.Parameters.AddWithValue("$v", value);
         cmd.ExecuteNonQuery();
     }
 


### PR DESCRIPTION
## Why

Cold-start restore chain ballooned to ~1 GB because Litestream was capturing ~127 MB LTX deltas every 5 minutes. Root cause: `DatabaseBackupService.PerformSqliteBackupAsync` opens/closes SQLite connections against `/tmp/storage.db` on every cycle, and closing a connection in WAL mode triggers a WAL->main checkpoint that rewrites all dirty pages. Litestream sees the page churn and uploads it.

Litestream already replicates the DB to Azure Blob Storage, so the secondary AzureFiles backup is redundant.

## What

Strip `DatabaseBackupService` down to:
- Restore cached images (`/data/images` -> `wwwroot/images`) on startup
- Periodically sync new images (`wwwroot/images` -> `/data/images`)
- Record system stats snapshots (read-only DB query, untouched)

Removed:
- `PerformSqliteBackupAsync` / `BackupToStorageAsync` / `ComputeFileHashAsync`
- `StopAsync` final-backup logic
- Hash-based skip optimization
- DB paths from `DatabaseBackupPaths` (now image + active-DB only)

## Risk

Loses the secondary `/data/storage.db` backup. Litestream is now the only DB backup, which is the standard pattern for SQLite-on-Container-Apps. Litestream restore on cold start should now be much faster as the LTX chain stops growing.

## Test

- `dotnet build rss-reader.sln` clean
- `dotnet test rss-reader.sln` -> 110/110 passing
- Reworked `DatabaseBackupServiceTests` to cover image sync, image restore, and explicit assertions that the service never touches the DB file (Litestream replication contract)