### PR TITLE
Fix SQLiteSystemStatsRepository.GetPerUserStats build error

### DIFF
--- a/src/Server/Data/SQLiteSystemStatsRepository.cs
+++ b/src/Server/Data/SQLiteSystemStatsRepository.cs
@@ -108,8 +108,7 @@ public class SQLiteSystemStatsRepository : ISystemStatsRepository
 
     public IEnumerable<UserStats> GetPerUserStats()
     {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.OpenWithPragmas();
+        using var connection = _connections.OpenRead();
 
         // LEFT JOIN ensures users with zero feeds/items still appear.
         // COUNT(DISTINCT) is needed because joining Feeds and Items on


### PR DESCRIPTION
PR #70's IDbConnections refactor missed GetPerUserStats, which still referenced the removed _connectionString field and OpenWithPragmas() extension method. main is currently failing dotnet build -c Release as a result, blocking deploys.

Fix: use _connections.OpenRead() to match the read-side pattern used by other repos.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>