### PR TITLE
Add ACA health probes to Bicep (writer + reader)

### DIFF
--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -193,6 +193,28 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
               mountPath: '/data'
             }
           ]
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/api/healthz'
+                port: 8080
+              }
+              periodSeconds: 30
+              timeoutSeconds: 5
+              failureThreshold: 3
+            }
+            {
+              type: 'Startup'
+              httpGet: {
+                path: '/api/healthz'
+                port: 8080
+              }
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 60
+            }
+          ]
         }
       ]
       scale: {
@@ -316,6 +338,28 @@ resource readerApp 'Microsoft.App/containerApps@2024-03-01' = if (enableReadRepl
             {
               name: 'RssAppConfig__DbLocation'
               value: '/tmp/storage.db'
+            }
+          ]
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/api/healthz'
+                port: 8080
+              }
+              periodSeconds: 30
+              timeoutSeconds: 5
+              failureThreshold: 3
+            }
+            {
+              type: 'Startup'
+              httpGet: {
+                path: '/api/healthz'
+                port: 8080
+              }
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 60
             }
           ]
         }


### PR DESCRIPTION
Live Container App had liveness/startup probes set manually via `az containerapp update` but pointed at `/healthz`  a path that doesn't exist (only `/api/healthz` is mapped). The probes were tolerant enough to limp along until a recent deploy tripped the startup deadline, requiring a hot-fix via `az containerapp update --yaml`.

This PR codifies the corrected probes in Bicep on both the writer and reader Container Apps so the config is reproducible and can't drift again.

- Path: `/api/healthz` (matches the actual route, `[AllowAnonymous]`)
- Port 8080
- Liveness: 30s period, 3 failures
- Startup: 10s period, 60 failures (10 min boot tolerance)

Note: this PR only adds the probes to source-of-truth  the live ACA already has the corrected probes from the hot-fix, so deploying this Bicep is a no-op against current state.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>