### PR TITLE
Chain logout through AAD's RP-initiated logout endpoint

### DIFF
--- a/src/WasmApp/Layout/NavMenu.razor
+++ b/src/WasmApp/Layout/NavMenu.razor
@@ -50,7 +50,7 @@
     <div class="desktop-nav-auth desktop-only">
         <AuthorizeView>
             <Authorized>
-                <a class="desktop-nav-link" href="/.auth/logout">Logout</a>
+                <a class="desktop-nav-link" href="@LogoutUrl">Logout</a>
             </Authorized>
             <NotAuthorized>
                 <a class="desktop-nav-link" href="/.auth/login/aad?prompt=select_account">Login</a>
@@ -107,7 +107,7 @@
                     </div>
                 }
                 <div class="nav-item px-3">
-                    <a class="nav-link" href="/.auth/logout">
+                    <a class="nav-link" href="@LogoutUrl">
                         Logout
                     </a>
                 </div>
@@ -129,6 +129,13 @@
 </div>
 
 @code {
+    // Chained logout: SWA logout -> AAD logout -> back to home.
+    // SWA's /.auth/logout only clears the SWA session cookie. To also terminate the
+    // AAD/MSA session (so the next login doesn't silently re-auth via the cached
+    // login.live.com cookie), we point post_logout_redirect_uri at AAD's RP-initiated
+    // logout endpoint, which then redirects back to the home page.
+    private const string LogoutUrl = "/.auth/logout?post_logout_redirect_uri=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Flogout%3Fpost_logout_redirect_uri%3Dhttps%253A%252F%252Frss.brandonchastain.com%252F";
+
     private string username = null;
     private RssUser feedUser = null;
     private bool collapseNavMenu = true;


### PR DESCRIPTION
## Why

SWA's `/.auth/logout` only clears the SWA session cookie. The IdP session at `login.microsoftonline.com` (and the upstream `login.live.com` cookie for personal Microsoft accounts) persists. When the user clicks Login again, MSA silently re-authenticates them as the same user without showing the account picker, even though we ask for `prompt=select_account` (which SWA's preconfigured AAD provider strips before forwarding to AAD anyway  see HAR analysis).

## Fix

Set `post_logout_redirect_uri` on `/.auth/logout` to chain through AAD's OIDC `end_session_endpoint`. The chain is:

```n/.auth/logout -> login.microsoftonline.com/common/oauth2/v2.0/logout -> rss.brandonchastain.com/
```n
AAD's logout endpoint terminates the AAD session (and triggers MSA logout for personal accounts) before redirecting back to the home page. Next login should now show the account picker correctly.

## Test plan

- `dotnet build` clean
- Manual: login  click Logout  verify URL bar shows AAD logout briefly  land on home page  click Login  MSA shows account picker (instead of auto-signing in)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>