### PR TITLE
Reverse logout chain: AAD logout first, then SWA logout

### DIFF
--- a/src/WasmApp/Layout/NavMenu.razor
+++ b/src/WasmApp/Layout/NavMenu.razor
@@ -129,12 +129,13 @@
 </div>
 
 @code {
-    // Chained logout: SWA logout -> AAD logout -> back to home.
-    // SWA's /.auth/logout only clears the SWA session cookie. To also terminate the
-    // AAD/MSA session (so the next login doesn't silently re-auth via the cached
-    // login.live.com cookie), we point post_logout_redirect_uri at AAD's RP-initiated
-    // logout endpoint, which then redirects back to the home page.
-    private const string LogoutUrl = "/.auth/logout?post_logout_redirect_uri=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Flogout%3Fpost_logout_redirect_uri%3Dhttps%253A%252F%252Frss.brandonchastain.com%252F";
+    // Chained logout: AAD logout -> SWA logout -> back to home.
+    // We hit AAD's RP-initiated logout endpoint FIRST so the IdP session (and the
+    // upstream login.live.com MSA cookie) is terminated. AAD then redirects to
+    // SWA's /.auth/logout which clears the SWA session cookie and lands on /.
+    // (We can't do SWA-then-AAD because SWA only honors RELATIVE values for its
+    // own post_logout_redirect_uri parameter, so it would strip the AAD URL.)
+    private const string LogoutUrl = "https://login.microsoftonline.com/common/oauth2/v2.0/logout?post_logout_redirect_uri=https%3A%2F%2Frss.brandonchastain.com%2F.auth%2Flogout%3Fpost_logout_redirect_uri%3D%252F";
 
     private string username = null;
     private RssUser feedUser = null;


### PR DESCRIPTION
Follow-up to #73. SWA only honors relative URLs in /.auth/logout's post_logout_redirect_uri, so the previous SWA-first chain stripped the AAD URL.

New chain: AAD logout (kills IdP/MSA session)  SWA /.auth/logout (clears SWA cookie, post_logout_redirect_uri=/)  home.