### PR TITLE
Two-step logout: SWA logout, then static bounce to AAD logout

### DIFF
--- a/src/WasmApp/Layout/NavMenu.razor
+++ b/src/WasmApp/Layout/NavMenu.razor
@@ -129,13 +129,15 @@
 </div>
 
 @code {
-    // Chained logout: AAD logout -> SWA logout -> back to home.
-    // We hit AAD's RP-initiated logout endpoint FIRST so the IdP session (and the
-    // upstream login.live.com MSA cookie) is terminated. AAD then redirects to
-    // SWA's /.auth/logout which clears the SWA session cookie and lands on /.
-    // (We can't do SWA-then-AAD because SWA only honors RELATIVE values for its
-    // own post_logout_redirect_uri parameter, so it would strip the AAD URL.)
-    private const string LogoutUrl = "https://login.microsoftonline.com/common/oauth2/v2.0/logout?post_logout_redirect_uri=https%3A%2F%2Frss.brandonchastain.com%2F.auth%2Flogout%3Fpost_logout_redirect_uri%3D%252F";
+    // Two-step logout chain:
+    //   1. SWA /.auth/logout clears the SWA session cookie, then redirects to a
+    //      relative URL (SWA only allows relative post_logout_redirect_uri values).
+    //   2. /signedout.html is a static bounce page that JS-redirects to AAD's
+    //      RP-initiated logout endpoint, which terminates the AAD/MSA session.
+    // We can't chain in a single hop because AAD's post_logout_redirect_uri must
+    // match a registered URI on the app registration, and we don't control the
+    // SWA preconfigured AAD app's registration.
+    private const string LogoutUrl = "/.auth/logout?post_logout_redirect_uri=/signedout.html";
 
     private string username = null;
     private RssUser feedUser = null;

--- a/src/WasmApp/wwwroot/signedout.html
+++ b/src/WasmApp/wwwroot/signedout.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Signing out…</title>
+  <meta name="robots" content="noindex">
+  <meta http-equiv="cache-control" content="no-store">
+  <script>
+    // Static bounce page hit by SWA after /.auth/logout clears the SWA cookie.
+    // We then redirect to AAD's RP-initiated logout endpoint to terminate the
+    // IdP/MSA session. AAD will display its "You're signed out" page (it ignores
+    // post_logout_redirect_uri unless it matches the registered logout URI list,
+    // which we cannot edit on the SWA preconfigured AAD app).
+    window.location.replace('https://login.microsoftonline.com/common/oauth2/v2.0/logout');
+  </script>
+</head>
+<body>
+  <p>Signing you out…</p>
+  <p>If you are not redirected, <a href="https://login.microsoftonline.com/common/oauth2/v2.0/logout">click here to finish signing out</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
Follow-up to #74. HAR analysis showed AAD logout fired and login.live.com/logout.srf cleared the MSA cookie, but AAD silently dropped the post_logout_redirect_uri (response was AAD's signed-out page, no 302), so SWA cookie was never cleared.

New chain:
1. /.auth/logout?post_logout_redirect_uri=/signedout.html (SWA accepts relative path, clears SWA cookie)
2. /signedout.html is a static page whose script redirects to AAD logout, terminating IdP/MSA session.

Final landing is AAD's 'You're signed out' page. UX-wise this is acceptable; both cookies are dead.