### PR TITLE
fix: replace Virtualize with plain @foreach on timeline to fix fast-scroll bug

### DIFF
--- a/src/WasmApp/Pages/Base/PostPageBase.razor
+++ b/src/WasmApp/Pages/Base/PostPageBase.razor
@@ -10,7 +10,6 @@
     private bool _pendingForceReset;
     private string _scrollAnchorPostId;
     private bool _needsScrollRestore;
-    private bool _scrolledToEstimate;
     private int _restorePageSize;
     public List<NewsFeedItem> Items { get; set; } = new List<NewsFeedItem>();
     public int Page { get; set; } = 0;
@@ -107,7 +106,7 @@
                 UpdateCursorFromItems(newPageRes);
             }
 
-            // Sync loaded item count to JS for scroll state estimation (works with Virtualize)
+            // Sync loaded item count to JS for scroll-state save estimation
             try { await jsRuntime.InvokeVoidAsync("rssApp.setLoadedItemCount", Items.Count); } catch { }
             
             this.StateHasChanged();
@@ -239,37 +238,15 @@
         {
             try
             {
-                // With Virtualize, the target post may not be in the DOM yet.
-                // First try a direct scroll; if it fails, estimate position to trigger
-                // Virtualize to render items near the target, then retry next render.
+                // All items are always in the DOM (no Virtualize), so scrollToPost
+                // will find the element on the first attempt after items are loaded.
                 var scrolled = await jsRuntime.InvokeAsync<bool>("rssApp.scrollToPost", _scrollAnchorPostId);
-                if (scrolled)
+                if (scrolled || Items.Any(i => i.Id == _scrollAnchorPostId))
                 {
                     _needsScrollRestore = false;
                     _scrollAnchorPostId = null;
                 }
-                else if (!_scrolledToEstimate)
-                {
-                    // Find the target's index in the loaded items and scroll to estimated position
-                    var targetIndex = Items.FindIndex(i => i.Id == _scrollAnchorPostId);
-                    if (targetIndex >= 0)
-                    {
-                        // Add ~1.1x multiplier to account for day headers interspersed
-                        await jsRuntime.InvokeVoidAsync("rssApp.scrollToEstimatedIndex", (int)(targetIndex * 1.1), 72);
-                        _scrolledToEstimate = true;
-                    }
-                    else
-                    {
-                        _needsScrollRestore = false;
-                    }
-                }
-                else
-                {
-                    // Already scrolled to estimate but element still not found — give up
-                    _needsScrollRestore = false;
-                    _scrollAnchorPostId = null;
-                    _scrolledToEstimate = false;
-                }
+                // else: items not yet loaded — try again next render cycle
             }
             catch (Exception)
             {

--- a/src/WasmApp/Pages/Detail/PostTable.razor
+++ b/src/WasmApp/Pages/Detail/PostTable.razor
@@ -3,7 +3,6 @@
 @rendermode InteractiveWebAssembly
 @attribute [StreamRendering]
 @attribute [Authorize]
-@using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Sve.Blazor.InfiniteScroll.Components
 @using WasmApp.Pages.Detail
 
@@ -40,7 +39,8 @@
     }
     else
     {
-        <Virtualize @ref="_virtualizeRef" Items="@_flatEntries" Context="entry" ItemSize="72" OverscanCount="10" SpacerElement="div">
+        @foreach (var entry in _flatEntries)
+        {
             @if (entry.IsDayHeader)
             {
                 <div @key="@entry.DayKey" class="day-separator @(entry.IsFirstHeader ? "day-separator-first" : "")">@GetDayLabel(entry.Date)</div>
@@ -52,7 +52,7 @@
                     FilterTag="@this.filterTag"
                     IsFilterUnread="@this.IsFilterUnread"/>
             }
-        </Virtualize>
+        }
 
         <InfiniteScroll ObserverTargetId="observerTarget" ObservableTargetReached="(e) => Next()">
             <div class="row">
@@ -86,9 +86,8 @@
     private string filterTag => FeedClient.FilterTag;
 
     private bool isLoading = true;
-    private Virtualize<TimelineEntry> _virtualizeRef;
 
-    // Pre-computed flat list for Virtualize — rebuilt only when Posts changes
+    // Pre-computed flat list for plain @foreach — rebuilt only when Posts changes
     private List<TimelineEntry> _flatEntries = new();
     private int _lastPostsCount;
 


### PR DESCRIPTION
## Problem

Fast-scrolling the \/timeline\ page with Page Down causes the post list to become \'messed up'\ and the user can no longer scroll back to the top.

## Root Cause

\<Virtualize ItemSize="72">\ in \PostTable.razor\ computes before/after spacer heights as \count  72\. The actual element heights are:
- Day separator headers: ~50 px  
- Post rows: ~95 px  
- True average: ~85 px (**vs assumed 72 px = ~18% error**)

Under fast scroll, Blazor maps \scrollY  item index\ via \loor(scrollY / ItemSize)\. With the wrong size, the wrong items render in the wrong viewport region and the spacer math diverges, trapping the scroll position (can't scroll back to top).

## Fix

Replace \<Virtualize>\ with a plain \@foreach\ loop in \PostTable.razor\.

**Why this is safe:**
- Items load 20/page via \InfiniteScroll\  even 10 pages loaded = 200 DOM elements, imperceptible render cost
- All items always in DOM  \scrollToPost()\ always succeeds on first try (no estimate fallback needed)
- Removes \_virtualizeRef\ (was declared but never called)

Also simplified scroll restore in \PostPageBase.razor\: removed \_scrolledToEstimate\ field and the \scrollToEstimatedIndex\ fallback branch  no longer needed.

## Testing

- \dotnet test\  110/110 pass  
- Playwright smoke test (headless Chromium):
  -  Desktop 1280800: items load, 8 PageDown works, Home returns scrollY=0
  -  Mobile 375812: same