### PR TITLE
Show loading spinner during initial timeline fetch

### DIFF
--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -20,7 +20,7 @@ param containerImage string
 param cpuCore string = '1.0'
 
 @description('Memory allocated to a single container instance')
-param memorySize string = '2.0Gi'
+param memorySize string = '1.0Gi'
 
 @description('Minimum number of replicas')
 param minReplicas int = 1

--- a/src/WasmApp/Pages/Base/PostPageBase.razor
+++ b/src/WasmApp/Pages/Base/PostPageBase.razor
@@ -8,6 +8,7 @@
 @code {
     private bool _isRefreshing;
     private bool _pendingForceReset;
+    private bool _hasLoadedOnce;
     private string _scrollAnchorPostId;
     private bool _needsScrollRestore;
     private int _restorePageSize;
@@ -16,6 +17,8 @@
     public long? CursorPublishDateOrder { get; set; }
     public long? CursorId { get; set; }
     protected bool initialized = false;
+
+    public bool IsLoading => !_hasLoadedOnce || _isRefreshing;
 
     protected class ScrollState
     {
@@ -114,6 +117,7 @@
         finally
         {
             _isRefreshing = false;
+            _hasLoadedOnce = true;
         }
 
         // If a forceReset arrived while we were fetching, run again now

--- a/src/WasmApp/Pages/Detail/PostTable.razor
+++ b/src/WasmApp/Pages/Detail/PostTable.razor
@@ -25,7 +25,7 @@
 
 
 <div id="post-table" class="table">
-    @if (isLoading && (_flatEntries == null || _flatEntries.Count == 0))
+    @if (IsLoading && (_flatEntries == null || _flatEntries.Count == 0))
     {
         <div class="loading-spinner-container">
             <div class="spinner"></div>
@@ -71,6 +71,9 @@
     [CascadingParameter(Name = "Page")]
     private int Page { get; set; }
 
+    [CascadingParameter(Name = "IsLoading")]
+    public bool IsLoading { get; set; }
+
     [Parameter]
     public EventCallback<int> OnPageChanged { get; set; }
 
@@ -84,8 +87,6 @@
     public bool IsFilterUnread => FeedClient.IsFilterUnread;
     public bool IsFilterSaved => FeedClient.IsFilterSaved;
     private string filterTag => FeedClient.FilterTag;
-
-    private bool isLoading = true;
 
     // Pre-computed flat list for plain @foreach — rebuilt only when Posts changes
     private List<TimelineEntry> _flatEntries = new();
@@ -112,7 +113,6 @@
         base.OnParametersSet();
         if (Posts != null)
         {
-            isLoading = false;
             RebuildFlatEntries();
         }
     }
@@ -145,30 +145,24 @@
 
     private async Task ToggleUnreadFilterAsync()
     {
-        isLoading = true;
         _lastPostsCount = 0; // force rebuild on next parameter set
         await this.OnRefreshTriggered.InvokeAsync((!this.IsFilterUnread, this.IsFilterSaved, this.filterTag, false));
-        isLoading = false;
     }
 
     private async Task ToggleSavedFilterAsync()
     {
-        isLoading = true;
         _lastPostsCount = 0;
         await this.OnRefreshTriggered.InvokeAsync((this.IsFilterUnread, !this.IsFilterSaved, this.filterTag, false));
-        isLoading = false;
     }
 
     private async Task FilterForTag(string tag)
     {
-        isLoading = true;
         _lastPostsCount = 0;
         if (this.filterTag == tag)
         {
             tag = null;
         }
         await this.OnRefreshTriggered.InvokeAsync((this.IsFilterUnread, this.IsFilterSaved, tag, false));
-        isLoading = false;
     }
 
     private async Task OnRefreshComplete()
@@ -179,9 +173,7 @@
 
     private async Task Next()
     {
-        isLoading = true;
         await this.OnPageChanged.InvokeAsync(this.Page + 1);
-        isLoading = false;
         await InvokeAsync(this.StateHasChanged);
     }
 

--- a/src/WasmApp/Pages/Posts.razor
+++ b/src/WasmApp/Pages/Posts.razor
@@ -14,7 +14,9 @@
 
 <CascadingValue Value="@Page" Name="Page">
 <CascadingValue Value="@Items" Name="Posts">
+<CascadingValue Value="@IsLoading" Name="IsLoading">
     <PostTable OnPageChanged="UpdatePage" FeedClient="@this.feedClient" OnRefreshTriggered="RefreshItems"/>
+</CascadingValue>
 </CascadingValue>
 </CascadingValue>
 

--- a/src/WasmApp/Pages/Search.razor
+++ b/src/WasmApp/Pages/Search.razor
@@ -25,7 +25,9 @@ else if (hasSearched)
 {
     <CascadingValue Value="@Page" Name="Page">
     <CascadingValue Value="@Items" Name="Posts">
+    <CascadingValue Value="@IsLoading" Name="IsLoading">
         <PostTable OnPageChanged="UpdatePage" FeedClient="@this.feedClient" OnRefreshTriggered="RefreshItems"/>
+    </CascadingValue>
     </CascadingValue>
     </CascadingValue>
 }

--- a/src/WasmApp/Pages/Timeline.razor
+++ b/src/WasmApp/Pages/Timeline.razor
@@ -12,7 +12,9 @@
 
 <CascadingValue Value="@Page" Name="Page">
 <CascadingValue Value="@Items" Name="Posts">
+<CascadingValue Value="@IsLoading" Name="IsLoading">
     <PostTable OnPageChanged="UpdatePage" FeedClient="@this.feedClient" OnRefreshTriggered="RefreshItems" />
+</CascadingValue>
 </CascadingValue>
 </CascadingValue>
 


### PR DESCRIPTION
PostPageBase initialized `Items` to an empty list, so `PostTable.OnParametersSet` flipped `isLoading=false` before the first fetch even started  yielding 'No posts found' instead of a spinner.

**Fix:** Move loading state into `PostPageBase` (`IsLoading => !_hasLoadedOnce || _isRefreshing`) and cascade it down to `PostTable` alongside `Posts` and `Page`. `_hasLoadedOnce` flips true in the `finally` of `RefreshItems`, so the spinner is shown until the first fetch completes and during any subsequent refresh.

Also aligns `infrastructure/main.bicep` `memorySize` default with the deployed Container App config (0.5 CPU / 1.0Gi).