### PR TITLE
Fast cold-start via file-mount DB backup; Litestream optional

### DIFF
--- a/infrastructure/docker-entrypoint.sh
+++ b/infrastructure/docker-entrypoint.sh
@@ -1,28 +1,55 @@
 #!/bin/sh
+#
+# Cold-start entrypoint.
+#
+# Default mode (RSSREADER_ENABLE_LITESTREAM_REPLICATION != "true"):
+#   Durability comes from the periodic file-mount backup service writing
+#   /tmp/storage.db to /data/storage.db (Azure Files). On boot we just `cp`
+#   /data → /tmp and exec dotnet. Cold start ≈ 5-15 sec regardless of DB size.
+#
+#   The migration path from the previous Litestream-only world is automatic:
+#   if /data/storage.db is missing AND a Litestream blob replica exists, we
+#   do a one-shot litestream restore and the backup service immediately
+#   persists it to /data on its first cycle.
+#
+# Scaling mode (RSSREADER_ENABLE_LITESTREAM_REPLICATION == "true"):
+#   Same /data seeding, but `litestream replicate` runs as the supervisor so
+#   readers can stream WAL from blob. Each writer cold start mints a fresh
+#   Litestream generation; readers must re-restore on generation change.
+#
+# See plan in session-state for full design.
+
+set -e
 
 APP_ROLE="${APP_ROLE:-writer}"
+LITESTREAM_ENABLED="${RSSREADER_ENABLE_LITESTREAM_REPLICATION:-false}"
+ACTIVE_DB="/tmp/storage.db"
+# Backup path is REQUIRED in production (set via Bicep) and EMPTY in local dev.
+# When empty, skip all seed/bootstrap logic — SQLite will create /tmp/storage.db
+# fresh, which is the desired local-dev behavior.
+BACKUP_DB="${RssAppConfig__BackupDbPath:-}"
+BACKUP_DIR=""
+if [ -n "$BACKUP_DB" ]; then
+    BACKUP_DIR="$(dirname "$BACKUP_DB")"
+fi
 
+# ---------------------------------------------------------------------------
+# Reader path: unchanged. Reader requires Litestream follow-mode.
+# ---------------------------------------------------------------------------
 if [ "$APP_ROLE" = "reader" ]; then
-    # Reader mode: continuously restore WAL changes from blob storage.
-    # litestream restore -f (follow mode) handles both the initial restore
-    # AND continuous polling for new LTX files (~1s lag behind writer).
-    # We skip the one-shot restore — follow mode manages the DB lifecycle
-    # including the -txid sidecar for crash recovery.
     echo "Starting in READER mode (read-only replica with follow-mode restore)." >&2
-    litestream restore -f -config /etc/litestream.yml /tmp/storage.db &
+    litestream restore -f -config /etc/litestream.yml "$ACTIVE_DB" &
     LITESTREAM_PID=$!
 
-    # Wait for the initial restore to produce the DB file
-    echo "Waiting for Litestream initial restore..." >&2
     elapsed=0
-    while [ ! -f /tmp/storage.db ] && [ $elapsed -lt 30 ]; do
+    while [ ! -f "$ACTIVE_DB" ] && [ $elapsed -lt 30 ]; do
         sleep 1
         elapsed=$((elapsed + 1))
     done
 
-    if [ ! -f /tmp/storage.db ]; then
+    if [ ! -f "$ACTIVE_DB" ]; then
         echo "ERROR: Litestream follow-mode restore timed out after 30s." >&2
-        kill $LITESTREAM_PID 2>/dev/null
+        kill $LITESTREAM_PID 2>/dev/null || true
         exit 1
     fi
 
@@ -30,26 +57,104 @@ if [ "$APP_ROLE" = "reader" ]; then
     exec dotnet Server.dll
 fi
 
-# Writer mode: restore from Litestream if a replica exists, then start
-# under Litestream's process supervision for continuous WAL replication.
-#
-# Litestream is now the SOLE backup path for the SQLite database — the previous
-# secondary AzureFiles backup (DatabaseBackupService -> /data/storage.db) was
-# removed. If `litestream restore` fails here, we MUST fail fast: starting the
-# app on an empty DB would cause `litestream replicate` to mint a fresh
-# generation against the empty file and orphan the existing replica
-# (silent data loss).
-if ! litestream restore -if-replica-exists -config /etc/litestream.yml /tmp/storage.db; then
-    echo "FATAL: litestream restore failed. Refusing to start with empty DB to avoid orphaning the replica." >&2
-    echo "       Investigate Litestream auth / blob connectivity before restarting." >&2
-    exit 1
+# ---------------------------------------------------------------------------
+# Writer path: seed from the file-mount backup.
+# ---------------------------------------------------------------------------
+
+# Local-dev escape: if no BackupDbPath is configured, skip seeding/bootstrap
+# entirely and let SQLite create /tmp/storage.db on first repository init.
+if [ -z "$BACKUP_DB" ]; then
+    echo "RssAppConfig__BackupDbPath is empty — skipping seed (local-dev mode)." >&2
+    if [ "$LITESTREAM_ENABLED" = "true" ]; then
+        echo "FATAL: RSSREADER_ENABLE_LITESTREAM_REPLICATION=true requires RssAppConfig__BackupDbPath." >&2
+        exit 1
+    fi
+    echo "Starting in DEFAULT mode (no backup configured; ephemeral local DB)." >&2
+    exec dotnet Server.dll
 fi
 
-# Litestream continuously replicates WAL changes to Blob Storage.
+# Validate the backup directory's grandparent (/data) exists and is writable.
+# The /data Azure Files mount is the production durability surface; its absence
+# means broken durability. The backup *subdir* may legitimately not exist on
+# first boot — we mkdir it below.
+PARENT_OF_BACKUP_DIR="$(dirname "$BACKUP_DIR")"
+if [ ! -d "$PARENT_OF_BACKUP_DIR" ]; then
+    echo "FATAL: Parent of backup directory '$PARENT_OF_BACKUP_DIR' does not exist." >&2
+    echo "       In production this means the Azure Files mount is missing." >&2
+    echo "       Check Container App volumeMounts configuration." >&2
+    exit 1
+fi
+if [ ! -w "$PARENT_OF_BACKUP_DIR" ]; then
+    echo "FATAL: Parent of backup directory '$PARENT_OF_BACKUP_DIR' is not writable." >&2
+    exit 1
+fi
+mkdir -p "$BACKUP_DIR"
+
+if [ -f "$BACKUP_DB" ]; then
+    # Fast path: copy the file-mount backup into local /tmp.
+    echo "Seeding $ACTIVE_DB from $BACKUP_DB..." >&2
+    cp "$BACKUP_DB" "$ACTIVE_DB"
+    SIZE=$(stat -c%s "$ACTIVE_DB" 2>/dev/null || echo "?")
+    echo "Seeded $SIZE bytes from file-mount backup." >&2
+
+    # Cheap integrity check on the copied seed. FATAL on failure — refusing to start
+    # prevents the backup service from then overwriting /data with bad data.
+    QC_RESULT=$(sqlite3 "$ACTIVE_DB" "PRAGMA quick_check;" 2>&1 || echo "FAILED")
+    if [ "$QC_RESULT" != "ok" ]; then
+        echo "FATAL: PRAGMA quick_check failed on seeded DB: $QC_RESULT" >&2
+        echo "       Refusing to start; manual recovery required." >&2
+        exit 1
+    fi
+    echo "quick_check on seeded DB: ok." >&2
+else
+    # No file-mount backup yet. Try the one-shot Litestream bootstrap path
+    # (existing prod system has a blob replica from the previous architecture).
+    echo "$BACKUP_DB not found — attempting one-shot Litestream restore." >&2
+    if litestream restore -if-replica-exists -config /etc/litestream.yml "$ACTIVE_DB"; then
+        if [ -f "$ACTIVE_DB" ]; then
+            # Atomic bootstrap publish: copy to a unique temp path, validate,
+            # then rename. A crash before rename leaves no /data/db/storage.db
+            # so the next boot retries the litestream restore path.
+            BOOTSTRAP_TMP="$BACKUP_DB.bootstrap.tmp.$$"
+            trap 'rm -f "$BOOTSTRAP_TMP"' EXIT
+            echo "One-shot Litestream restore succeeded; staging to $BOOTSTRAP_TMP." >&2
+            cp "$ACTIVE_DB" "$BOOTSTRAP_TMP"
+            BS_QC=$(sqlite3 "$BOOTSTRAP_TMP" "PRAGMA quick_check;" 2>&1 || echo "FAILED")
+            if [ "$BS_QC" != "ok" ]; then
+                echo "FATAL: quick_check failed on bootstrapped DB: $BS_QC" >&2
+                rm -f "$BOOTSTRAP_TMP"
+                exit 1
+            fi
+            mv -f "$BOOTSTRAP_TMP" "$BACKUP_DB"
+            trap - EXIT
+            echo "Bootstrapped $BACKUP_DB from Litestream replica." >&2
+        else
+            echo "FATAL: No /data backup and no Litestream replica found." >&2
+            echo "       For brand-new environments, pre-create an empty DB at $BACKUP_DB." >&2
+            exit 1
+        fi
+    else
+        echo "FATAL: Litestream restore failed and no /data backup is present." >&2
+        echo "       Investigate Litestream auth / blob connectivity." >&2
+        exit 1
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Default mode: file-mount backup is sole durability.
+# ---------------------------------------------------------------------------
+if [ "$LITESTREAM_ENABLED" != "true" ]; then
+    echo "Starting in DEFAULT mode (file-mount backup; Litestream replication OFF)." >&2
+    exec dotnet Server.dll
+fi
+
+# ---------------------------------------------------------------------------
+# Scaling mode: Litestream replicates from the seeded DB. NOTE: this MINTS A
+# NEW GENERATION in blob from /data state on every writer cold start. Readers
+# must re-restore. Roll out per the sequenced procedure in the plan.
+# ---------------------------------------------------------------------------
+echo "Starting in SCALING mode (Litestream replication ON)." >&2
 litestream replicate -exec "dotnet Server.dll" -config /etc/litestream.yml
 exit_code=$?
-
-# If `litestream replicate` itself exits, surface the error rather than running
-# unreplicated — the app would write to /tmp/storage.db with no backup at all.
-echo "FATAL: litestream replicate exited ($exit_code). Container will exit so it can be restarted with replication." >&2
+echo "FATAL: litestream replicate exited ($exit_code). Container will exit." >&2
 exit $exit_code

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -135,6 +135,10 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     environmentId: environment.id
     configuration: {
+      // Single-revision mode minimizes old/new revision overlap during deploy.
+      // Two writer revisions running concurrently would race on /data/storage.db
+      // (mitigated by the BackupToFile lock file, but Single is the proper fix).
+      activeRevisionsMode: 'Single'
       registries: [
         {
           server: 'ghcr.io'
@@ -185,6 +189,24 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'LITESTREAM_AZURE_ACCOUNT_NAME'
               value: storageAccount.name
+            }
+            {
+              // Default off: file-mount backup is sole durability. Set to 'true'
+              // only when rolling out scaling mode (read replicas), per the
+              // sequenced rollout in plan.md.
+              name: 'RSSREADER_ENABLE_LITESTREAM_REPLICATION'
+              value: 'false'
+            }
+            {
+              // Persistent SQLite backup file on the Azure Files mount.
+              // The DatabaseBackupToFileService writes here every 5 min;
+              // the entrypoint seeds /tmp/storage.db from this on cold start.
+              //
+              // NOTE: Path is intentionally inside a NEW subdirectory `/data/db/`
+              // so that any pre-existing `/data/storage.db` (left over from a
+              // previous architecture) cannot be silently trusted as a seed.
+              name: 'RssAppConfig__BackupDbPath'
+              value: '/data/db/storage.db'
             }
           ]
           volumeMounts: [

--- a/src/Server/Config/RssAppConfig.cs
+++ b/src/Server/Config/RssAppConfig.cs
@@ -7,6 +7,14 @@ namespace RssApp.Config
         public string ServerHostName { get; set; } = "https://localhost:8080/";
         public string DbLocation { get; set; }
         public bool IsTestUserEnabled { get; set; }
+
+        // Persistent backup file path on the Azure Files mount (or local disk in dev).
+        // Empty string disables the backup-to-file service entirely.
+        // The parent directory must exist and be writable; otherwise the writer
+        // entrypoint and the BackgroundService will fail fast.
+        public string BackupDbPath { get; set; } = string.Empty;
+        public TimeSpan BackupInterval { get; set; } = TimeSpan.FromMinutes(5);
+
         public TimeSpan CacheReloadInterval { get; set; } = TimeSpan.FromMinutes(5);
         public TimeSpan CacheReloadStartupDelay { get; set; } = TimeSpan.FromSeconds(0);
         public bool IsReadOnly { get; set; }

--- a/src/Server/Dockerfile
+++ b/src/Server/Dockerfile
@@ -21,6 +21,10 @@ RUN dotnet publish "Server.csproj" -c Release -o /app/publish /p:UseAppHost=fals
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app
 
+# Install sqlite3 CLI for cold-start quick_check on the seeded DB
+RUN apt-get update && apt-get install -y --no-install-recommends sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install Litestream for continuous SQLite replication to Azure Blob Storage
 ADD --checksum=sha256:e8612ef5424802723e8cfa2d07a182df60f9af71839b5ff5ef1e80dff38efbdd \
     https://github.com/benbjohnson/litestream/releases/download/v0.5.9/litestream-0.5.9-linux-x86_64.tar.gz \

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -99,6 +99,15 @@ if (!config.IsReadOnly)
                 new DatabaseBackupPaths(),
                 sb))
         .AddHostedService(p => p.GetRequiredService<DatabaseBackupService>())
+        .AddSingleton<DatabaseBackupToFileService>(sb =>
+            new DatabaseBackupToFileService(
+                sb.GetRequiredService<ILogger<DatabaseBackupToFileService>>(),
+                new DatabaseBackupToFilePaths(
+                    ActiveDbPath: config.DbLocation,
+                    BackupDbPath: config.BackupDbPath ?? string.Empty,
+                    Interval: config.BackupInterval,
+                    LockStaleThreshold: TimeSpan.FromMinutes(15))))
+        .AddHostedService(p => p.GetRequiredService<DatabaseBackupToFileService>())
         .AddHostedService<BackgroundWorker>()
         .AddSingleton<IFeedRefresher, FeedRefresher>()
         .AddTransient<RedirectDowngradeHandler>()

--- a/src/Server/Services/DatabaseBackupToFileService.cs
+++ b/src/Server/Services/DatabaseBackupToFileService.cs
@@ -1,0 +1,356 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace RssReader.Server.Services
+{
+    /// <summary>
+    /// Configuration for the file-mount DB backup. Empty <see cref="BackupDbPath"/> disables
+    /// the service entirely (used in local dev when /data is not mounted).
+    /// </summary>
+    public record DatabaseBackupToFilePaths(
+        string ActiveDbPath,
+        string BackupDbPath,
+        TimeSpan Interval,
+        TimeSpan LockStaleThreshold)
+    {
+        public string LockPath => BackupDbPath + ".lock";
+
+        /// <summary>Glob-friendly prefix for per-writer temp files.</summary>
+        public string TempPrefix => Path.GetFileName(BackupDbPath) + ".tmp.";
+    }
+
+    /// <summary>
+    /// Periodically copies the live SQLite database from <see cref="DatabaseBackupToFilePaths.ActiveDbPath"/>
+    /// (ephemeral container disk) to <see cref="DatabaseBackupToFilePaths.BackupDbPath"/> on the
+    /// persistent Azure Files mount. The startup entrypoint seeds <c>/tmp</c> from this file,
+    /// making cold-start independent of DB history length and replacing Litestream as the sole
+    /// durability mechanism in default operating mode.
+    ///
+    /// Safety contract:
+    ///   - Uses SQLite's online <c>BackupDatabase</c> API (no WAL checkpoint forced on source).
+    ///   - Writes to a unique temp path, runs <c>PRAGMA quick_check</c>, then atomically renames.
+    ///   - Holds a lock file on the share to prevent two writer revisions racing.
+    ///   - This is SEPARATE from <see cref="DatabaseBackupService"/>, which still owns image
+    ///     sync and stats and must NEVER write the DB.
+    /// </summary>
+    public class DatabaseBackupToFileService : BackgroundService
+    {
+        private readonly ILogger<DatabaseBackupToFileService> _logger;
+        private readonly DatabaseBackupToFilePaths _paths;
+        private readonly string _hostName;
+        private readonly int _processId;
+        private readonly string _ownerToken;
+
+        public DateTimeOffset? LastSuccessAtUtc { get; private set; }
+
+        public bool Enabled => !string.IsNullOrEmpty(_paths.BackupDbPath);
+
+        public DatabaseBackupToFileService(
+            ILogger<DatabaseBackupToFileService> logger,
+            DatabaseBackupToFilePaths paths)
+        {
+            _logger = logger;
+            _paths = paths;
+            _hostName = Environment.MachineName;
+            _processId = Environment.ProcessId;
+            _ownerToken = Guid.NewGuid().ToString("N");
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (!Enabled)
+            {
+                _logger.LogInformation(
+                    "DatabaseBackupToFileService disabled (BackupDbPath empty). Skipping.");
+                return;
+            }
+
+            // Validate parent directory once at startup; fail fast if missing/unwritable.
+            var parent = Path.GetDirectoryName(_paths.BackupDbPath);
+            if (string.IsNullOrEmpty(parent) || !Directory.Exists(parent))
+            {
+                throw new InvalidOperationException(
+                    $"BackupDbPath parent directory does not exist: '{parent}'. " +
+                    "In production this means the /data Azure Files mount is missing — " +
+                    "refusing to run silently.");
+            }
+
+            _logger.LogInformation(
+                "DatabaseBackupToFileService running. Active={Active}, Backup={Backup}, Interval={Interval}",
+                _paths.ActiveDbPath, _paths.BackupDbPath, _paths.Interval);
+
+            // Run an initial cycle quickly so a fresh container has a backup before
+            // crashing or being recycled (rather than waiting one full interval).
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                await RunBackupCycleAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) { return; }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Initial DB backup cycle failed");
+            }
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(_paths.Interval, stoppingToken);
+                    if (stoppingToken.IsCancellationRequested) break;
+                    await RunBackupCycleAsync(stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "DatabaseBackupToFileService cycle failed");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Run one backup cycle. Returns true if a backup was successfully written;
+        /// false if it was skipped (e.g. another writer holds the lock).
+        /// Exposed for tests.
+        /// </summary>
+        internal async Task<bool> RunBackupCycleAsync(CancellationToken cancellationToken)
+        {
+            if (!Enabled) return false;
+
+            CleanupStaleTempFiles();
+
+            if (!TryAcquireLock(out var lockFs))
+            {
+                _logger.LogInformation(
+                    "Another writer holds the backup lock — skipping this cycle.");
+                return false;
+            }
+
+            var sw = Stopwatch.StartNew();
+            var tempPath = $"{_paths.BackupDbPath}.tmp.{_hostName}.{_processId}.{Guid.NewGuid():N}";
+            try
+            {
+                if (!File.Exists(_paths.ActiveDbPath))
+                {
+                    _logger.LogWarning(
+                        "Active DB '{Path}' does not exist — refusing to overwrite backup.",
+                        _paths.ActiveDbPath);
+                    return false;
+                }
+
+                await BackupSqliteAsync(_paths.ActiveDbPath, tempPath, cancellationToken);
+
+                if (!QuickCheck(tempPath))
+                {
+                    _logger.LogError(
+                        "PRAGMA quick_check failed on temp backup '{Temp}' — discarding.",
+                        tempPath);
+                    SafeDelete(tempPath);
+                    return false;
+                }
+
+                // Atomic rename. File.Move with overwrite=true uses rename(2) on Linux.
+                File.Move(tempPath, _paths.BackupDbPath, overwrite: true);
+
+                LastSuccessAtUtc = DateTimeOffset.UtcNow;
+                var size = new FileInfo(_paths.BackupDbPath).Length;
+                _logger.LogInformation(
+                    "DB backup OK: {Bytes:N0} bytes in {Ms} ms (host={Host} pid={Pid}).",
+                    size, sw.ElapsedMilliseconds, _hostName, _processId);
+                return true;
+            }
+            finally
+            {
+                SafeDelete(tempPath); // no-op if rename succeeded
+                // SQLite may leave -wal/-shm sidecars next to the temp file
+                // when the destination connection ran in WAL mode. Sweep them
+                // so we don't accumulate cruft in the backup directory.
+                SafeDelete(tempPath + "-wal");
+                SafeDelete(tempPath + "-shm");
+                ReleaseLock(lockFs);
+            }
+        }
+
+        /// <summary>
+        /// Cleanup orphaned temp files older than 2× the lock-stale threshold.
+        /// Exposed for tests.
+        /// </summary>
+        internal void CleanupStaleTempFiles()
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_paths.BackupDbPath);
+                if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir)) return;
+
+                var cutoff = DateTime.UtcNow - (_paths.LockStaleThreshold + _paths.LockStaleThreshold);
+                foreach (var path in Directory.EnumerateFiles(dir, _paths.TempPrefix + "*"))
+                {
+                    try
+                    {
+                        if (File.GetLastWriteTimeUtc(path) < cutoff)
+                        {
+                            File.Delete(path);
+                            _logger.LogInformation("Deleted stale temp file: {Path}", path);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to cleanup temp file {Path}", path);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Stale temp cleanup failed");
+            }
+        }
+
+        private bool TryAcquireLock(out FileStream? lockFs)
+        {
+            lockFs = null;
+
+            try
+            {
+                if (File.Exists(_paths.LockPath))
+                {
+                    var age = DateTime.UtcNow - File.GetLastWriteTimeUtc(_paths.LockPath);
+                    if (age < _paths.LockStaleThreshold)
+                    {
+                        return false;
+                    }
+                    _logger.LogWarning(
+                        "Stale backup lock found (age={Age}) — taking over.", age);
+                    SafeDelete(_paths.LockPath);
+                }
+
+                lockFs = new FileStream(
+                    _paths.LockPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.Read);
+
+                using var writer = new StreamWriter(lockFs, leaveOpen: true);
+                // First line is the owner token; readers compare on release to
+                // avoid an old writer deleting a newer writer's lock.
+                writer.WriteLine(_ownerToken);
+                writer.WriteLine($"{_hostName}:{_processId}:{DateTimeOffset.UtcNow:O}");
+                writer.Flush();
+                return true;
+            }
+            catch (IOException)
+            {
+                // Lost the race — another container created the lock between our check and our create.
+                lockFs?.Dispose();
+                lockFs = null;
+                return false;
+            }
+        }
+
+        private void ReleaseLock(FileStream? lockFs)
+        {
+            try
+            {
+                lockFs?.Dispose();
+
+                // Only delete if we still own it. An old/stalled writer must not
+                // delete a fresh lock that a newer writer took over.
+                if (File.Exists(_paths.LockPath))
+                {
+                    string? firstLine = null;
+                    try
+                    {
+                        using var reader = new StreamReader(_paths.LockPath);
+                        firstLine = reader.ReadLine();
+                    }
+                    catch (IOException) { }
+
+                    if (firstLine == _ownerToken)
+                    {
+                        SafeDelete(_paths.LockPath);
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "Lock token mismatch on release — leaving lock for the current owner.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to release backup lock");
+            }
+        }
+
+        private static async Task BackupSqliteAsync(
+            string sourcePath, string destPath, CancellationToken cancellationToken)
+        {
+            await Task.Run(() =>
+            {
+                using (var src = new SqliteConnection(
+                    $"Data Source={sourcePath};Mode=ReadOnly;Pooling=False"))
+                using (var dst = new SqliteConnection(
+                    $"Data Source={destPath};Pooling=False"))
+                {
+                    src.Open();
+                    ApplyBusyTimeout(src);
+                    dst.Open();
+                    ApplyBusyTimeout(dst);
+                    src.BackupDatabase(dst);
+
+                    // Force the destination out of WAL mode so the -wal/-shm
+                    // sidecar files are checkpointed and removed when we close.
+                    // Without this, every cycle leaves orphan sidecars in the
+                    // backup dir because the post-backup File.Move only renames
+                    // the main file.
+                    using var pragma = dst.CreateCommand();
+                    pragma.CommandText = "PRAGMA journal_mode=DELETE;";
+                    pragma.ExecuteNonQuery();
+                }
+
+                // Belt-and-suspenders: if the SQLite provider left sidecars
+                // behind despite the journal_mode change, sweep them.
+                SafeDelete(destPath + "-wal");
+                SafeDelete(destPath + "-shm");
+            }, cancellationToken);
+        }
+
+        private static void ApplyBusyTimeout(SqliteConnection conn)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "PRAGMA busy_timeout = 30000;";
+            cmd.ExecuteNonQuery();
+        }
+
+        private static bool QuickCheck(string path)
+        {
+            try
+            {
+                using var conn = new SqliteConnection(
+                    $"Data Source={path};Mode=ReadOnly;Pooling=False");
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = "PRAGMA quick_check";
+                var result = cmd.ExecuteScalar() as string;
+                return string.Equals(result, "ok", StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void SafeDelete(string path)
+        {
+            try { if (File.Exists(path)) File.Delete(path); } catch { }
+        }
+    }
+}

--- a/test/SerializerTests/DatabaseBackupToFileServiceTests.cs
+++ b/test/SerializerTests/DatabaseBackupToFileServiceTests.cs
@@ -1,0 +1,261 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using RssReader.Server.Services;
+
+namespace SerializerTests;
+
+[TestClass]
+public class DatabaseBackupToFileServiceTests
+{
+    private string _testDir = null!;
+    private string _activeDbPath = null!;
+    private string _backupDbPath = null!;
+    private DatabaseBackupToFilePaths _paths = null!;
+    private DatabaseBackupToFileService _service = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "DatabaseBackupToFileServiceTests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDir);
+
+        var activeDir = Path.Combine(_testDir, "active");
+        var backupDir = Path.Combine(_testDir, "backup");
+        Directory.CreateDirectory(activeDir);
+        Directory.CreateDirectory(backupDir);
+
+        _activeDbPath = Path.Combine(activeDir, "storage.db");
+        _backupDbPath = Path.Combine(backupDir, "storage.db");
+
+        _paths = new DatabaseBackupToFilePaths(
+            ActiveDbPath: _activeDbPath,
+            BackupDbPath: _backupDbPath,
+            Interval: TimeSpan.FromMinutes(5),
+            LockStaleThreshold: TimeSpan.FromSeconds(10));
+
+        _service = new DatabaseBackupToFileService(
+            NullLogger<DatabaseBackupToFileService>.Instance,
+            _paths);
+
+        SeedSqliteDb(_activeDbPath, ("alpha", 1), ("beta", 2));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        SqliteConnection.ClearAllPools();
+        Thread.Sleep(50);
+        try
+        {
+            if (Directory.Exists(_testDir))
+                Directory.Delete(_testDir, recursive: true);
+        }
+        catch (IOException) { }
+    }
+
+    [TestMethod]
+    public async Task RunBackup_ProducesValidSqliteFileWithSameRows()
+    {
+        var ok = await _service.RunBackupCycleAsync(CancellationToken.None);
+
+        Assert.IsTrue(ok, "Backup cycle should succeed");
+        Assert.IsTrue(File.Exists(_backupDbPath), "Backup file should exist at target path");
+
+        var rows = ReadAllRows(_backupDbPath);
+        CollectionAssert.AreEquivalent(
+            new[] { ("alpha", 1), ("beta", 2) },
+            rows.ToArray());
+    }
+
+    [TestMethod]
+    public async Task RunBackup_RecordsLastSuccessTimestamp()
+    {
+        Assert.IsNull(_service.LastSuccessAtUtc);
+        await _service.RunBackupCycleAsync(CancellationToken.None);
+        Assert.IsNotNull(_service.LastSuccessAtUtc);
+    }
+
+    [TestMethod]
+    public async Task RunBackup_LeavesNoTempFilesOnSuccess()
+    {
+        await _service.RunBackupCycleAsync(CancellationToken.None);
+
+        var backupDir = Path.GetDirectoryName(_backupDbPath)!;
+        var tmpFiles = Directory.GetFiles(backupDir, "*.tmp.*");
+        Assert.AreEqual(0, tmpFiles.Length, "No leftover temp files on successful backup");
+    }
+
+    [TestMethod]
+    public async Task RunBackup_LeavesNoLockFileOnSuccess()
+    {
+        await _service.RunBackupCycleAsync(CancellationToken.None);
+        Assert.IsFalse(File.Exists(_backupDbPath + ".lock"),
+            "Lock file should be released on success");
+    }
+
+    [TestMethod]
+    public async Task RunBackup_SkipsWhenAnotherWriterHoldsLock()
+    {
+        // Simulate another writer with a fresh lock file.
+        File.WriteAllText(_paths.LockPath, "other-host:9999:active");
+
+        var ok = await _service.RunBackupCycleAsync(CancellationToken.None);
+
+        Assert.IsFalse(ok, "Should skip when another writer holds the lock");
+        Assert.IsFalse(File.Exists(_backupDbPath),
+            "No backup should be written when locked out");
+        Assert.IsTrue(File.Exists(_paths.LockPath),
+            "We must NOT delete a fresh lock owned by another writer");
+    }
+
+    [TestMethod]
+    public async Task RunBackup_TakesOverStaleLock()
+    {
+        // Place a stale lock (mtime older than threshold).
+        File.WriteAllText(_paths.LockPath, "crashed-host:1234");
+        File.SetLastWriteTimeUtc(_paths.LockPath, DateTime.UtcNow - TimeSpan.FromMinutes(30));
+
+        var ok = await _service.RunBackupCycleAsync(CancellationToken.None);
+
+        Assert.IsTrue(ok, "Should take over a stale lock and run successfully");
+        Assert.IsTrue(File.Exists(_backupDbPath));
+    }
+
+    [TestMethod]
+    public async Task RunBackup_LockFileContainsOwnerTokenOnFirstLine()
+    {
+        // Pause the cycle by holding a lock externally with a stale mtime so
+        // our service takes it over. After the cycle completes successfully,
+        // the lock should be released. Write a SECOND cycle's lock manually
+        // and verify our service's lock format starts with a token line —
+        // this is what the release path uses to identify ownership.
+        File.WriteAllText(_paths.LockPath, "crashed-host:1234");
+        File.SetLastWriteTimeUtc(_paths.LockPath, DateTime.UtcNow - TimeSpan.FromMinutes(30));
+
+        // Hook: peek at the lock file content during the cycle by intercepting
+        // via FileSystemWatcher. Simpler: create the source DB, run cycle, then
+        // we don't have visibility. Instead verify the release-path contract by
+        // a direct test: write a foreign-token lock, mark it stale, run cycle.
+        // After cycle: lock should be GONE (we own it during the cycle, then
+        // release it). The token check protects the case where someone else
+        // overwrote the lock file mid-cycle, which is harder to simulate.
+        var ok = await _service.RunBackupCycleAsync(CancellationToken.None);
+        Assert.IsTrue(ok);
+        Assert.IsFalse(File.Exists(_paths.LockPath),
+            "Our own lock should be released after a successful cycle");
+    }
+
+    [TestMethod]
+    public async Task RunBackup_DisabledWhenBackupPathEmpty()
+    {
+        var paths = new DatabaseBackupToFilePaths(
+            ActiveDbPath: _activeDbPath,
+            BackupDbPath: string.Empty,
+            Interval: TimeSpan.FromMinutes(5),
+            LockStaleThreshold: TimeSpan.FromSeconds(10));
+        var svc = new DatabaseBackupToFileService(
+            NullLogger<DatabaseBackupToFileService>.Instance, paths);
+
+        Assert.IsFalse(svc.Enabled);
+        var ok = await svc.RunBackupCycleAsync(CancellationToken.None);
+        Assert.IsFalse(ok);
+    }
+
+    [TestMethod]
+    public async Task RunBackup_RefusesWhenActiveDbMissing()
+    {
+        File.Delete(_activeDbPath);
+
+        var ok = await _service.RunBackupCycleAsync(CancellationToken.None);
+
+        Assert.IsFalse(ok);
+        Assert.IsFalse(File.Exists(_backupDbPath),
+            "Must not overwrite backup with empty data when source is missing");
+    }
+
+    [TestMethod]
+    public void CleanupStaleTempFiles_RemovesOldTempFilesOnly()
+    {
+        var backupDir = Path.GetDirectoryName(_backupDbPath)!;
+        var basename = Path.GetFileName(_backupDbPath);
+
+        var stale = Path.Combine(backupDir, $"{basename}.tmp.host.123.aaaa");
+        var fresh = Path.Combine(backupDir, $"{basename}.tmp.host.456.bbbb");
+        var unrelated = Path.Combine(backupDir, "unrelated-file.txt");
+
+        File.WriteAllText(stale, "stale");
+        File.WriteAllText(fresh, "fresh");
+        File.WriteAllText(unrelated, "unrelated");
+
+        // Cutoff = 2× LockStaleThreshold (10s in tests) = 20s.
+        File.SetLastWriteTimeUtc(stale, DateTime.UtcNow - TimeSpan.FromMinutes(5));
+        File.SetLastWriteTimeUtc(fresh, DateTime.UtcNow);
+
+        _service.CleanupStaleTempFiles();
+
+        Assert.IsFalse(File.Exists(stale), "Stale tmp file should be deleted");
+        Assert.IsTrue(File.Exists(fresh), "Fresh tmp file should be preserved");
+        Assert.IsTrue(File.Exists(unrelated), "Unrelated files should not be touched");
+    }
+
+    [TestMethod]
+    public async Task RunBackup_OverwritesPreviousBackupFile()
+    {
+        // First cycle.
+        await _service.RunBackupCycleAsync(CancellationToken.None);
+        Assert.AreEqual(2, ReadAllRows(_backupDbPath).Count);
+
+        // Mutate active DB.
+        SqliteConnection.ClearAllPools();
+        AddRow(_activeDbPath, "gamma", 3);
+
+        // Second cycle.
+        var ok = await _service.RunBackupCycleAsync(CancellationToken.None);
+        Assert.IsTrue(ok);
+        var rows = ReadAllRows(_backupDbPath);
+        Assert.AreEqual(3, rows.Count, "Second backup should overwrite the first");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static void SeedSqliteDb(string path, params (string Name, int Value)[] rows)
+    {
+        using var conn = new SqliteConnection($"Data Source={path};Pooling=False");
+        conn.Open();
+        using var create = conn.CreateCommand();
+        create.CommandText = "CREATE TABLE IF NOT EXISTS kv (name TEXT, value INTEGER);";
+        create.ExecuteNonQuery();
+        foreach (var (n, v) in rows)
+        {
+            using var insert = conn.CreateCommand();
+            insert.CommandText = "INSERT INTO kv (name, value) VALUES ($n, $v);";
+            insert.Parameters.AddWithValue("$n", n);
+            insert.Parameters.AddWithValue("$v", v);
+            insert.ExecuteNonQuery();
+        }
+    }
+
+    private static void AddRow(string path, string name, int value)
+    {
+        using var conn = new SqliteConnection($"Data Source={path};Pooling=False");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "INSERT INTO kv (name, value) VALUES ($n, $v);";
+        cmd.Parameters.AddWithValue("$n", name);
+        cmd.Parameters.AddWithValue("$v", value);
+        cmd.ExecuteNonQuery();
+    }
+
+    private static List<(string Name, int Value)> ReadAllRows(string path)
+    {
+        var rows = new List<(string, int)>();
+        using var conn = new SqliteConnection($"Data Source={path};Mode=ReadOnly;Pooling=False");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT name, value FROM kv ORDER BY name;";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            rows.Add((reader.GetString(0), reader.GetInt32(1)));
+        return rows;
+    }
+}


### PR DESCRIPTION
Reduce container cold-start from ~6 min to ~10-15 sec by replacing Litestream WAL replay (for durability) with a periodic file-mount backup. Litestream is preserved for future read-replica scaling but disabled by default.

## Architecture

| Mode | Default (v1) | Scaling (future) |
|---|---|---|
| Trigger | nableReadReplica=false | Both flags 	rue |
| Cold start | cp /data/db/storage.db -> /tmp (~10s) | Same seed, then litestream replicate |
| Durability | DatabaseBackupToFileService (5 min) | Same + Litestream blob |

## Changes

- New \DatabaseBackupToFileService\ (singleton + hosted) writes /tmp -> /data/db/storage.db every 5 min via SQLite \BackupDatabase\ API. Lock file with owner-token, atomic rename, quick_check on temp, journal_mode=DELETE + sidecar sweep.
- Rewrote \docker-entrypoint.sh\: validates /data, mkdir backup subdir, seed-or-bootstrap branching with FATAL on missing seed, one-shot litestream restore for migration, atomic bootstrap publish.
- Backup path is /data/db/**storage.db** (new subdir) so any stale legacy /data/storage.db cannot be silently used as a seed.
- Bicep: \ctiveRevisionsMode: 'Single'\ on writer; \RSSREADER_ENABLE_LITESTREAM_REPLICATION='false'\; \RssAppConfig__BackupDbPath='/data/db/storage.db'\.
- Dockerfile: install \sqlite3\ for entrypoint quick_check.

## Local validation

- Seed-from-backup path: 4KB seed copied into /tmp, quick_check ok, healthz 200.
- Backup cycle: /data/db/storage.db grew 4KB  90KB after repository init, mtime updated, no leftover -wal/-shm sidecars.
- 121/121 tests pass.

## Production rollout

First v1 deploy: /data/db/storage.db is missing -> entrypoint takes the one-shot Litestream restore path (one-time ~6 min cost), atomically publishes to /data/db/storage.db. Subsequent boots: ~10-15 sec.