### PR TITLE
Set minReplicas default to 0 (scale-to-zero)

### DIFF
--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -23,7 +23,7 @@ param cpuCore string = '1.0'
 param memorySize string = '1.0Gi'
 
 @description('Minimum number of replicas')
-param minReplicas int = 1
+param minReplicas int = 0
 
 @description('Maximum number of replicas')
 param maxReplicas int = 1


### PR DESCRIPTION
Bicep was still defaulting to 1; the fast cold-start work was meant to enable scale-to-zero. Live ACA already updated.